### PR TITLE
Ensure promotion suffix only for pawn moves

### DIFF
--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -101,9 +101,7 @@ func (h *Handler) HandleMove(w http.ResponseWriter, r *http.Request) {
 	}
 
 	uci := strings.ToLower(strings.TrimSpace(m.UCI))
-	if len(uci) == 4 && isPromotionToLastRank(uci) {
-		uci += "q"
-	}
+	uci = appendPromotionIfPawn(g, uci)
 
 	// Handle castling moves - ensure they're properly formatted
 	if len(uci) == 4 {

--- a/internal/handlers/middleware.go
+++ b/internal/handlers/middleware.go
@@ -3,6 +3,9 @@ package handlers
 import (
 	"encoding/json"
 	"net/http"
+
+	"github.com/notnil/chess"
+	"tinychess/internal/game"
 )
 
 // WriteJSON writes a JSON response with the given status code
@@ -12,13 +15,51 @@ func WriteJSON(w http.ResponseWriter, status int, v any) {
 	_ = json.NewEncoder(w).Encode(v)
 }
 
-// isPromotionToLastRank checks if a 4-character UCI move is a promotion to the last rank
-func isPromotionToLastRank(uci string) bool {
+// appendPromotionIfPawn appends a queen promotion suffix if the move is a pawn
+// reaching the last rank. Non-pawn moves are returned unchanged.
+func appendPromotionIfPawn(g *game.Game, uci string) string {
 	if len(uci) != 4 {
-		return false
+		return uci
 	}
+
 	to := uci[2:]
-	return to[1] == '1' || to[1] == '8'
+	if to[1] != '1' && to[1] != '8' {
+		return uci
+	}
+
+	sq := parseSquare(uci[:2])
+	if sq == chess.NoSquare {
+		return uci
+	}
+
+	g.Mu.Lock()
+	state := g.StateLocked()
+	g.Mu.Unlock()
+
+	fenOpt, err := chess.FEN(state.FEN)
+	if err != nil {
+		return uci
+	}
+	tmp := chess.NewGame(fenOpt)
+	piece := tmp.Position().Board().Piece(sq)
+
+	if piece.Type() == chess.Pawn {
+		return uci + "q"
+	}
+	return uci
+}
+
+// parseSquare converts a coordinate string like "e2" into a chess.Square.
+func parseSquare(s string) chess.Square {
+	if len(s) != 2 {
+		return chess.NoSquare
+	}
+	file := s[0] - 'a'
+	rank := s[1] - '1'
+	if file > 7 || rank > 7 {
+		return chess.NoSquare
+	}
+	return chess.Square(rank*8 + file)
 }
 
 // isAllowedEmoji checks if an emoji is in the allowed list

--- a/internal/handlers/middleware_test.go
+++ b/internal/handlers/middleware_test.go
@@ -1,0 +1,40 @@
+package handlers
+
+import (
+	"testing"
+
+	"tinychess/internal/game"
+)
+
+func newGame() *game.Game {
+	hub := game.NewHub()
+	return hub.Get("test")
+}
+
+func TestAppendPromotionIfPawnRank8(t *testing.T) {
+	g := newGame()
+	if got := appendPromotionIfPawn(g, "a7a8"); got != "a7a8q" {
+		t.Fatalf("expected a7a8q got %s", got)
+	}
+}
+
+func TestAppendPromotionIfPawnRank1(t *testing.T) {
+	g := newGame()
+	if got := appendPromotionIfPawn(g, "a7a1"); got != "a7a1q" {
+		t.Fatalf("expected a7a1q got %s", got)
+	}
+}
+
+func TestNoPromotionForQueen(t *testing.T) {
+	g := newGame()
+	if got := appendPromotionIfPawn(g, "d1d8"); got != "d1d8" {
+		t.Fatalf("queen move modified: %s", got)
+	}
+}
+
+func TestNoPromotionForRook(t *testing.T) {
+	g := newGame()
+	if got := appendPromotionIfPawn(g, "a8a1"); got != "a8a1" {
+		t.Fatalf("rook move modified: %s", got)
+	}
+}


### PR DESCRIPTION
## Summary
- verify the moving piece is a pawn before appending promotion suffix
- add regression tests for pawn promotions and last-rank queen/rook moves

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bd88cd5a288320b02cb7d842902694