### PR TITLE
Add optional debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
 # Tiny Chess
 
 A simple web-based chess game that you can play with just a link.
+
+## Debug logging
+
+Verbose logging can help during development. Run the server with the
+`-debug` flag to enable additional log output:
+
+```
+go run . -debug
+```
+
+Or when using the compiled binary:
+
+```
+./bin/tinychess -debug
+```

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/notnil/chess"
+	"tinychess/internal/logging"
 )
 
 // Touch updates the last seen timestamp for a game
@@ -74,19 +75,19 @@ func (g *Game) MakeMove(uci string) error {
 
 	// Debug: Print current position and legal moves
 	pos := g.g.Position()
-	fmt.Printf("DEBUG: Attempting move %s on position %s\n", uci, pos.String())
+	logging.Debugf("Attempting move %s on position %s", uci, pos.String())
 
 	legalMoves := g.g.Moves()
-	fmt.Printf("DEBUG: Legal moves count: %d\n", len(legalMoves))
+	logging.Debugf("Legal moves count: %d", len(legalMoves))
 
 	// Try to decode the move
 	move, err := chess.UCINotation{}.Decode(pos, uci)
 	if err != nil {
-		fmt.Printf("DEBUG: UCI decode error: %v\n", err)
+		logging.Debugf("UCI decode error: %v", err)
 		return err
 	}
 
-	fmt.Printf("DEBUG: Decoded move: %s -> %s\n", move.S1(), move.S2())
+	logging.Debugf("Decoded move: %s -> %s", move.S1(), move.S2())
 
 	// Check if the move is in the legal moves list
 	isLegal := false
@@ -98,7 +99,7 @@ func (g *Game) MakeMove(uci string) error {
 	}
 
 	if !isLegal {
-		fmt.Printf("DEBUG: Move %s is not in legal moves list\n", uci)
+		logging.Debugf("Move %s is not in legal moves list", uci)
 		// Let's try to make the move anyway - the chess library might have additional validation
 		err = g.g.Move(move)
 		if err != nil {
@@ -116,7 +117,7 @@ func (g *Game) Reset() {
 	g.g = chess.NewGame()
 	// Debug: Print initial game state
 	pos := g.g.Position()
-	fmt.Printf("DEBUG: Game reset - FEN: %s, Castling: %s\n", pos.String(), pos.CastleRights())
+	logging.Debugf("Game reset - FEN: %s, Castling: %s", pos.String(), pos.CastleRights())
 	g.Mu.Unlock()
 }
 

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"tinychess/internal/game"
+	"tinychess/internal/logging"
 	"tinychess/internal/templates"
 
 	"github.com/google/uuid"
@@ -109,7 +110,7 @@ func (h *Handler) HandleMove(w http.ResponseWriter, r *http.Request) {
 	if len(uci) == 4 {
 		// Check for castling moves
 		if uci == "e1g1" || uci == "e1c1" || uci == "e8g8" || uci == "e8c8" {
-			fmt.Printf("DEBUG: Castling move detected: %s\n", uci)
+			logging.Debugf("Castling move detected: %s", uci)
 		}
 	}
 

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,13 @@
+package logging
+
+import "log"
+
+// Debug controls whether debug logs are printed.
+var Debug bool
+
+// Debugf logs a formatted debug message when Debug is enabled.
+func Debugf(format string, v ...any) {
+	if Debug {
+		log.Printf("DEBUG: "+format, v...)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,14 +1,20 @@
 package main
 
 import (
+	"flag"
 	"log"
 	"net/http"
 
 	"tinychess/internal/game"
 	"tinychess/internal/handlers"
+	"tinychess/internal/logging"
 )
 
 func main() {
+	debug := flag.Bool("debug", false, "enable debug logging")
+	flag.Parse()
+	logging.Debug = *debug
+
 	// Initialize game hub
 	hub := game.NewHub()
 


### PR DESCRIPTION
## Summary
- replace fmt.Printf debug statements with logger gated by debug flag
- add `-debug` command line flag to toggle verbose logging
- document enabling debug logs in README

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bd88cef6d483208ca649c4c740d6ef