### PR TITLE
Simplify move validation and add tests

### DIFF
--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -72,39 +72,9 @@ func (g *Game) MakeMove(uci string) error {
 	g.Mu.Lock()
 	defer g.Mu.Unlock()
 
-	// Debug: Print current position and legal moves
-	pos := g.g.Position()
-	fmt.Printf("DEBUG: Attempting move %s on position %s\n", uci, pos.String())
-
-	legalMoves := g.g.Moves()
-	fmt.Printf("DEBUG: Legal moves count: %d\n", len(legalMoves))
-
-	// Try to decode the move
-	move, err := chess.UCINotation{}.Decode(pos, uci)
+	move, err := chess.UCINotation{}.Decode(g.g.Position(), uci)
 	if err != nil {
-		fmt.Printf("DEBUG: UCI decode error: %v\n", err)
 		return err
-	}
-
-	fmt.Printf("DEBUG: Decoded move: %s -> %s\n", move.S1(), move.S2())
-
-	// Check if the move is in the legal moves list
-	isLegal := false
-	for _, legalMove := range legalMoves {
-		if legalMove.S1() == move.S1() && legalMove.S2() == move.S2() {
-			isLegal = true
-			break
-		}
-	}
-
-	if !isLegal {
-		fmt.Printf("DEBUG: Move %s is not in legal moves list\n", uci)
-		// Let's try to make the move anyway - the chess library might have additional validation
-		err = g.g.Move(move)
-		if err != nil {
-			return fmt.Errorf("illegal move: %s (%v)", uci, err)
-		}
-		return nil
 	}
 
 	return g.g.Move(move)

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -1,0 +1,31 @@
+package game
+
+import (
+	"testing"
+	"time"
+
+	"github.com/notnil/chess"
+)
+
+// helper to create a new Game with necessary fields
+func newTestGame() *Game {
+	return &Game{
+		g:         chess.NewGame(),
+		Watchers:  make(map[chan []byte]struct{}),
+		LastReact: make(map[string]time.Time),
+	}
+}
+
+func TestMakeMoveValid(t *testing.T) {
+	g := newTestGame()
+	if err := g.MakeMove("e2e4"); err != nil {
+		t.Fatalf("expected move to be valid, got error: %v", err)
+	}
+}
+
+func TestMakeMoveInvalid(t *testing.T) {
+	g := newTestGame()
+	if err := g.MakeMove("e2e5"); err == nil {
+		t.Fatalf("expected error for illegal move, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- simplify move validation by relying on chess engine's Move errors
- add unit tests for valid and invalid UCI moves

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bd88ce398c8320a29ff4b6a97c1151