### PR TITLE
Use MoveStr for move validation

### DIFF
--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -73,48 +73,13 @@ func (g *Game) MakeMove(uci string) error {
 	g.Mu.Lock()
 	defer g.Mu.Unlock()
 
-	// Debug: Print current position and legal moves
-	pos := g.g.Position()
-	logging.Debugf("Attempting move %s on position %s", uci, pos.String())
-
-	legalMoves := g.g.Moves()
-	logging.Debugf("Legal moves count: %d", len(legalMoves))
-
-	// Try to decode the move
-	move, err := chess.UCINotation{}.Decode(pos, uci)
-	if err != nil {
-		logging.Debugf("UCI decode error: %v", err)
-		return err
-	}
-
-	logging.Debugf("Decoded move: %s -> %s", move.S1(), move.S2())
-
-	// Check if the move is in the legal moves list
-	isLegal := false
-	for _, legalMove := range legalMoves {
-		if legalMove.S1() == move.S1() && legalMove.S2() == move.S2() {
-			isLegal = true
-			break
-		}
-	}
-
-	if !isLegal {
-		logging.Debugf("Move %s is not in legal moves list", uci)
-		// Let's try to make the move anyway - the chess library might have additional validation
-		err = g.g.Move(move)
-		if err != nil {
-			return fmt.Errorf("illegal move: %s (%v)", uci, err)
-		}
-		return nil
-	}
-
-	return g.g.Move(move)
+	return g.g.MoveStr(uci)
 }
 
 // Reset resets the game to the starting position
 func (g *Game) Reset() {
 	g.Mu.Lock()
-	g.g = chess.NewGame()
+	g.g = chess.NewGame(chess.UseNotation(chess.UCINotation{}))
 	// Debug: Print initial game state
 	pos := g.g.Position()
 	logging.Debugf("Game reset - FEN: %s, Castling: %s", pos.String(), pos.CastleRights())

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -10,7 +10,7 @@ import (
 // helper to create a new Game with necessary fields
 func newTestGame() *Game {
 	return &Game{
-		g:         chess.NewGame(),
+		g:         chess.NewGame(chess.UseNotation(chess.UCINotation{})),
 		Watchers:  make(map[chan []byte]struct{}),
 		LastReact: make(map[string]time.Time),
 	}
@@ -23,9 +23,16 @@ func TestMakeMoveValid(t *testing.T) {
 	}
 }
 
-func TestMakeMoveInvalid(t *testing.T) {
+func TestMakeMoveIllegal(t *testing.T) {
 	g := newTestGame()
 	if err := g.MakeMove("e2e5"); err == nil {
 		t.Fatalf("expected error for illegal move, got nil")
+	}
+}
+
+func TestMakeMoveInvalidUCI(t *testing.T) {
+	g := newTestGame()
+	if err := g.MakeMove("invalid"); err == nil {
+		t.Fatalf("expected error for invalid UCI, got nil")
 	}
 }

--- a/internal/game/hub.go
+++ b/internal/game/hub.go
@@ -36,7 +36,7 @@ func (h *Hub) Get(id string) *Game {
 		return g
 	}
 	ng := &Game{
-		g:         chess.NewGame(),
+		g:         chess.NewGame(chess.UseNotation(chess.UCINotation{})),
 		Watchers:  make(map[chan []byte]struct{}),
 		LastReact: make(map[string]time.Time),
 		Clients:   make(map[string]time.Time),


### PR DESCRIPTION
## Summary
- simplify move handling by calling `MoveStr` directly
- ensure games use UCI notation and reset appropriately
- test invalid and malformed moves

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bd95ae01488320bccbdf057680107c