### PR TITLE
Display commit hash in footer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ BIN := bin/$(APP)
 PKG := .
 PORT ?= 8080
 
-# ldflags embeds a build stamp; feel free to remove
-LDFLAGS := -s -w -X 'main.build=$$(date -u +%Y%m%d-%H%M%S)'
+# ldflags embeds a build stamp and commit hash; feel free to remove
+LDFLAGS := -s -w -X 'main.build=$$(date -u +%Y%m%d-%H%M%S)' -X 'main.commit=$$(git rev-parse --short HEAD)'
 
 .PHONY: all build run dev clean lint test race
 

--- a/internal/templates/game.html
+++ b/internal/templates/game.html
@@ -394,6 +394,7 @@
     </div>
   </div>
   <footer>Built with Go, SSE & vanilla JS — with ❤️ by Dusty and his traumatized 🤖</footer>
+  <div class="version">{{COMMIT}}</div>
   <script defer data-domain="tinychess.bitchimfabulo.us"
     src="https://plausible.io/js/script.outbound-links.js"></script>
   <script>

--- a/internal/templates/home.html
+++ b/internal/templates/home.html
@@ -210,6 +210,7 @@
   </section>
 
   <footer>Built with Go, SSE & vanilla JS — with ❤️ by Dusty and his traumatized 🤖</footer>
+  <div class="version">{{COMMIT}}</div>
   <script defer data-domain="tinychess.bitchimfabulo.us"
     src="https://plausible.io/js/script.outbound-links.js"></script>
   <script>

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -7,6 +7,10 @@ import (
 	"strings"
 )
 
+var commit = "dev"
+
+func SetCommit(c string) { commit = c }
+
 // WriteHomeHTML serves the home page template
 func WriteHomeHTML(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -18,7 +22,8 @@ func WriteHomeHTML(w http.ResponseWriter) {
 		http.Error(w, "Template not found", http.StatusInternalServerError)
 		return
 	}
-	_, _ = w.Write(content)
+	html := strings.ReplaceAll(string(content), "{{COMMIT}}", commit)
+	_, _ = w.Write([]byte(html))
 }
 
 // WriteGameHTML serves the game page template with game ID substitution
@@ -34,6 +39,7 @@ func WriteGameHTML(w http.ResponseWriter, gameID string) {
 	}
 
 	html := strings.ReplaceAll(string(content), "{{GAME_ID}}", gameID)
+	html = strings.ReplaceAll(html, "{{COMMIT}}", commit)
 	_, _ = w.Write([]byte(html))
 }
 

--- a/main.go
+++ b/main.go
@@ -8,12 +8,15 @@ import (
 	"tinychess/internal/game"
 	"tinychess/internal/handlers"
 	"tinychess/internal/logging"
+	"tinychess/internal/templates"
 )
 
 func main() {
 	debug := flag.Bool("debug", false, "enable debug logging")
 	flag.Parse()
 	logging.Debug = *debug
+
+	templates.SetCommit(commit)
 
 	// Initialize game hub
 	hub := game.NewHub()

--- a/version.go
+++ b/version.go
@@ -1,0 +1,3 @@
+package main
+
+var commit = "dev"


### PR DESCRIPTION
## Summary
- Embed commit hash into build via Makefile `LDFLAGS` and propagate to templates.
- Expose commit version to templates and render in home and game HTML footers.

## Testing
- `go test ./...`
- `make build`
- `curl -s http://localhost:8080/ | grep -n "version"`


------
https://chatgpt.com/codex/tasks/task_e_68be3832c7908320a4c130353e4dfc2a