### PR TITLE
feat: show git hash in dev footer

### DIFF
--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -63,7 +63,7 @@ func (h *Handler) HandleSSE(w http.ResponseWriter, r *http.Request) {
 	initial, _ := json.Marshal(g.StateLocked())
 	g.Mu.Unlock()
 
-	fmt.Fprintf(w, "data: %s\n\n", initial)
+	_, _ = fmt.Fprintf(w, "data: %s\n\n", initial)
 	flusher.Flush()
 
 	g.Touch()

--- a/internal/templates/game.html
+++ b/internal/templates/game.html
@@ -224,6 +224,11 @@
       text-align: center;
     }
 
+    footer .version {
+      margin-top: 4px;
+      font-size: 12px;
+    }
+
     .theme {
       display: flex;
       gap: 6px;
@@ -393,8 +398,10 @@
         with the link can move.</p>
     </div>
   </div>
-  <footer>Built with Go, SSE & vanilla JS — with ❤️ by Dusty and his traumatized 🤖</footer>
-  <div class="version">{{COMMIT}}</div>
+  <footer>
+    Built with Go, SSE & vanilla JS — with ❤️ by Dusty and his traumatized 🤖
+    <div class="version">{{COMMIT}}</div>
+  </footer>
   <script defer data-domain="tinychess.bitchimfabulo.us"
     src="https://plausible.io/js/script.outbound-links.js"></script>
   <script>

--- a/internal/templates/home.html
+++ b/internal/templates/home.html
@@ -144,6 +144,11 @@
       text-align: center;
     }
 
+    footer .version {
+      margin-top: 4px;
+      font-size: 12px;
+    }
+
     /* Recent list */
     .recent {
       max-width: 800px;
@@ -209,8 +214,10 @@
     <div id="recent"></div>
   </section>
 
-  <footer>Built with Go, SSE & vanilla JS — with ❤️ by Dusty and his traumatized 🤖</footer>
-  <div class="version">{{COMMIT}}</div>
+  <footer>
+    Built with Go, SSE & vanilla JS — with ❤️ by Dusty and his traumatized 🤖
+    <div class="version">{{COMMIT}}</div>
+  </footer>
   <script defer data-domain="tinychess.bitchimfabulo.us"
     src="https://plausible.io/js/script.outbound-links.js"></script>
   <script>

--- a/version.go
+++ b/version.go
@@ -1,3 +1,29 @@
 package main
 
+import (
+	"os/exec"
+	"runtime/debug"
+	"strings"
+)
+
 var commit = "dev"
+
+func init() {
+	if commit != "dev" {
+		return
+	}
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, s := range info.Settings {
+			if s.Key == "vcs.revision" && s.Value != "" {
+				commit = s.Value
+				if len(commit) > 7 {
+					commit = commit[:7]
+				}
+				return
+			}
+		}
+	}
+	if c, err := exec.Command("git", "rev-parse", "--short", "HEAD").Output(); err == nil {
+		commit = strings.TrimSpace(string(c))
+	}
+}


### PR DESCRIPTION
## Summary
- derive git short hash from build metadata with fallback to git
- center footer version string by moving it inside the footer

## Testing
- `go test ./...`
- `go build ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68be3bc5a3d08320bc8a1ef8c7581a24