### PR TITLE
Link footer version to commit

### DIFF
--- a/internal/templates/game.html
+++ b/internal/templates/game.html
@@ -400,7 +400,7 @@
   </div>
   <footer>
     Built with Go, SSE & vanilla JS — with ❤️ by Dusty and his traumatized 🤖
-    <div class="version">{{COMMIT}}</div>
+    <div class="version">Version: <a href="https://github.com/dustywusty/tinychess/tree/{{COMMIT}}">{{COMMIT}}</a></div>
   </footer>
   <script defer data-domain="tinychess.bitchimfabulo.us"
     src="https://plausible.io/js/script.outbound-links.js"></script>

--- a/internal/templates/home.html
+++ b/internal/templates/home.html
@@ -216,7 +216,7 @@
 
   <footer>
     Built with Go, SSE & vanilla JS — with ❤️ by Dusty and his traumatized 🤖
-    <div class="version">{{COMMIT}}</div>
+    <div class="version">Version: <a href="https://github.com/dustywusty/tinychess/tree/{{COMMIT}}">{{COMMIT}}</a></div>
   </footer>
   <script defer data-domain="tinychess.bitchimfabulo.us"
     src="https://plausible.io/js/script.outbound-links.js"></script>


### PR DESCRIPTION
## Summary
- make footer version display as link to corresponding GitHub commit

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68be40e1054c83208b8dd5dbf3c79d12