### PR TITLE
Use flat high-contrast chess piece colors

### DIFF
--- a/internal/templates/game.html
+++ b/internal/templates/game.html
@@ -124,14 +124,11 @@
     /* Fixed piece colors so they never flip on dark/light squares */
     .white-piece {
       color: #ffffff;
-      -webkit-text-stroke: 1px #0b0d11;
-      text-shadow: 0 0 0.5px rgba(0, 0, 0, .5);
+      -webkit-text-stroke: 1px #000000;
     }
 
     .black-piece {
-      color: #0b0d11;
-      -webkit-text-stroke: 1px #eaeef5;
-      text-shadow: 0 0 0.5px rgba(255, 255, 255, .5);
+      color: #000000;
     }
 
     .cell.sel {


### PR DESCRIPTION
## Summary
- simplify chess piece styles for better visibility
- render white pieces with black stroke and black pieces solid black

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68be47b1368c8320bbcb65418e2d24ce