### PR TITLE
Track game owner and assign client colors

### DIFF
--- a/internal/game/hub.go
+++ b/internal/game/hub.go
@@ -1,6 +1,7 @@
 package game
 
 import (
+	"math/rand"
 	"time"
 
 	"github.com/notnil/chess"
@@ -28,20 +29,50 @@ func NewHub() *Hub {
 	return h
 }
 
-// Get retrieves an existing game or creates a new one
-func (h *Hub) Get(id string) *Game {
+// Get retrieves an existing game or creates a new one. If a clientId is provided,
+// the first one becomes the owner and is assigned a random color. Subsequent
+// clients are assigned the opposite color.
+func (h *Hub) Get(id, clientId string) *Game {
 	h.Mu.Lock()
-	defer h.Mu.Unlock()
-	if g, ok := h.Games[id]; ok {
+	g, ok := h.Games[id]
+	if !ok {
+		color := chess.White
+		if rand.Intn(2) == 0 {
+			color = chess.Black
+		}
+		g = &Game{
+			g:          chess.NewGame(chess.UseNotation(chess.UCINotation{})),
+			Watchers:   make(map[chan []byte]struct{}),
+			LastReact:  make(map[string]time.Time),
+			Clients:    make(map[string]chess.Color),
+			LastSeen:   time.Now(),
+			OwnerColor: color,
+		}
+		if clientId != "" {
+			g.OwnerID = clientId
+			g.Clients[clientId] = g.OwnerColor
+		}
+		h.Games[id] = g
+		h.Mu.Unlock()
 		return g
 	}
-	ng := &Game{
-		g:         chess.NewGame(chess.UseNotation(chess.UCINotation{})),
-		Watchers:  make(map[chan []byte]struct{}),
-		LastReact: make(map[string]time.Time),
-		Clients:   make(map[string]time.Time),
-		LastSeen:  time.Now(),
+	h.Mu.Unlock()
+
+	if clientId != "" {
+		g.Mu.Lock()
+		if g.OwnerID == "" {
+			g.OwnerID = clientId
+			g.Clients[clientId] = g.OwnerColor
+		} else if _, exists := g.Clients[clientId]; !exists {
+			var color chess.Color
+			if g.OwnerColor == chess.White {
+				color = chess.Black
+			} else {
+				color = chess.White
+			}
+			g.Clients[clientId] = color
+		}
+		g.Mu.Unlock()
 	}
-	h.Games[id] = ng
-	return ng
+	return g
 }

--- a/internal/game/hub_test.go
+++ b/internal/game/hub_test.go
@@ -3,6 +3,8 @@ package game
 import (
 	"testing"
 	"time"
+
+	"github.com/notnil/chess"
 )
 
 // runCleanup mimics the hub's cleanup routine for testing purposes.
@@ -21,7 +23,7 @@ func runCleanup(h *Hub) {
 
 func TestGamePersistenceBeforeCleanup(t *testing.T) {
 	h := NewHub()
-	g := h.Get("test")
+	g := h.Get("test", "")
 
 	// Simulate a game that was last seen 23 hours ago.
 	g.Mu.Lock()
@@ -49,5 +51,29 @@ func TestGamePersistenceBeforeCleanup(t *testing.T) {
 	h.Mu.Unlock()
 	if exists {
 		t.Fatalf("game not removed after 24 hours of inactivity")
+	}
+}
+
+func TestOwnerAndClientColorAssignment(t *testing.T) {
+	h := NewHub()
+	g := h.Get("g1", "owner")
+
+	if g.OwnerID != "owner" {
+		t.Fatalf("expected owner id to be set")
+	}
+	ownerColor := g.OwnerColor
+	if c, ok := g.Clients["owner"]; !ok || c != ownerColor {
+		t.Fatalf("owner not recorded with correct color")
+	}
+
+	g = h.Get("g1", "client2")
+	var expected chess.Color
+	if ownerColor == chess.White {
+		expected = chess.Black
+	} else {
+		expected = chess.White
+	}
+	if c := g.Clients["client2"]; c != expected {
+		t.Fatalf("expected client2 color %v, got %v", expected, c)
 	}
 }

--- a/internal/game/types.go
+++ b/internal/game/types.go
@@ -15,12 +15,14 @@ type Hub struct {
 
 // Game represents a single chess game with its state and watchers
 type Game struct {
-	Mu        sync.Mutex
-	g         *chess.Game
-	Watchers  map[chan []byte]struct{}
-	LastReact map[string]time.Time
-	LastSeen  time.Time
-	Clients   map[string]time.Time // clientId -> last seen
+	Mu         sync.Mutex
+	g          *chess.Game
+	Watchers   map[chan []byte]struct{}
+	LastReact  map[string]time.Time
+	LastSeen   time.Time
+	OwnerID    string
+	OwnerColor chess.Color
+	Clients    map[string]chess.Color // clientId -> color
 }
 
 // MoveRequest represents a move request from a client

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -38,14 +38,15 @@ func (h *Handler) HandlePage(w http.ResponseWriter, r *http.Request) {
 		templates.WriteHomeHTML(w)
 		return
 	}
-	_ = h.Hub.Get(path)
+	_ = h.Hub.Get(path, "")
 	templates.WriteGameHTML(w, path)
 }
 
 // HandleSSE handles Server-Sent Events for real-time game updates
 func (h *Handler) HandleSSE(w http.ResponseWriter, r *http.Request) {
 	id := strings.TrimPrefix(r.URL.Path, "/sse/")
-	g := h.Hub.Get(id)
+	clientID := r.URL.Query().Get("clientId")
+	g := h.Hub.Get(id, clientID)
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
@@ -93,7 +94,7 @@ func (h *Handler) HandleSSE(w http.ResponseWriter, r *http.Request) {
 // HandleMove processes a chess move
 func (h *Handler) HandleMove(w http.ResponseWriter, r *http.Request) {
 	id := strings.TrimPrefix(r.URL.Path, "/move/")
-	g := h.Hub.Get(id)
+	g := h.Hub.Get(id, "")
 
 	var m game.MoveRequest
 	if err := json.NewDecoder(r.Body).Decode(&m); err != nil {
@@ -135,7 +136,7 @@ func (h *Handler) HandleMove(w http.ResponseWriter, r *http.Request) {
 // HandleReact processes a reaction/emoji
 func (h *Handler) HandleReact(w http.ResponseWriter, r *http.Request) {
 	id := strings.TrimPrefix(r.URL.Path, "/react/")
-	g := h.Hub.Get(id)
+	g := h.Hub.Get(id, "")
 
 	var body game.ReactionRequest
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -168,7 +169,7 @@ func (h *Handler) HandleReact(w http.ResponseWriter, r *http.Request) {
 // HandleReset resets a game to the starting position
 func (h *Handler) HandleReset(w http.ResponseWriter, r *http.Request) {
 	id := strings.TrimPrefix(r.URL.Path, "/reset/")
-	g := h.Hub.Get(id)
+	g := h.Hub.Get(id, "")
 
 	g.Reset()
 

--- a/internal/handlers/middleware_test.go
+++ b/internal/handlers/middleware_test.go
@@ -8,7 +8,7 @@ import (
 
 func newGame() *game.Game {
 	hub := game.NewHub()
-	return hub.Get("test")
+	return hub.Get("test", "")
 }
 
 func TestAppendPromotionIfPawnRank8(t *testing.T) {

--- a/internal/templates/game.html
+++ b/internal/templates/game.html
@@ -771,7 +771,7 @@
       status('');
 
       if (gameId) {
-        const es = new EventSource('/sse/' + gameId);
+        const es = new EventSource('/sse/' + gameId + '?clientId=' + encodeURIComponent(clientId));
         es.onmessage = (ev) => {
           const st = JSON.parse(ev.data || "{}");
           if (st.kind === 'emoji') {


### PR DESCRIPTION
## Summary
- record owner ID and randomly assigned color on new games
- track connecting clients with opposing colors and propagate client IDs through SSE
- include client ID in front-end SSE requests and add unit test for color assignments

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68be4b8eaccc8320a48492e9b8f7a62c