### PR TITLE
Support black-oriented board rendering

### DIFF
--- a/internal/templates/game.html
+++ b/internal/templates/game.html
@@ -429,6 +429,10 @@
       const reactBar = document.getElementById('reactbar');
       gameIdEl.textContent = gameId || '(none)';
 
+      // Orientation (default white, ?color=black flips board)
+      const params = new URLSearchParams(location.search);
+      const playerColor = params.get('color') === 'black' ? 'black' : 'white';
+
       // Theme picker
       const root = document.documentElement;
       let theme = localStorage.getItem('theme') || 'dark';
@@ -527,6 +531,11 @@
 
       // --- board helpers ---
       function cellSquare(row, col) {
+        if (playerColor === 'black') {
+          const file = String.fromCharCode('a'.charCodeAt(0) + (7 - col));
+          const rank = String(row + 1);
+          return file + rank;
+        }
         const file = String.fromCharCode('a'.charCodeAt(0) + col);
         const rank = String(8 - row);
         return file + rank;
@@ -538,7 +547,7 @@
 
         for (let r = 0; r < 8; r++) {
           const row = document.createElement('div'); row.className = 'rank';
-          const fenRank = board[r];
+          const fenRank = board[playerColor === 'black' ? 7 - r : r];
           const cells = [];
 
           for (let i = 0; i < fenRank.length; i++) {
@@ -552,7 +561,7 @@
           }
 
           for (let c = 0; c < 8; c++) {
-            const piece = cells[c] || '';
+            const piece = cells[playerColor === 'black' ? 7 - c : c] || '';
             const cell = document.createElement('div');
             cell.className = 'cell ' + (((r + c) % 2 === 1) ? 'light' : 'dark'); // a8 dark
             const sq = cellSquare(r, c);
@@ -567,16 +576,16 @@
             }
 
             // coordinates
-            if (r === 7) {
+            if ((playerColor === 'white' && r === 7) || (playerColor === 'black' && r === 0)) {
               const f = document.createElement('span');
               f.className = 'coord coord-file';
-              f.textContent = String.fromCharCode(97 + c);
+              f.textContent = sq[0];
               cell.appendChild(f);
             }
-            if (c === 0) {
+            if ((playerColor === 'white' && c === 0) || (playerColor === 'black' && c === 7)) {
               const rr = document.createElement('span');
               rr.className = 'coord coord-rank';
-              rr.textContent = String(8 - r);
+              rr.textContent = sq[1];
               cell.appendChild(rr);
             }
 
@@ -618,9 +627,9 @@
         const rect = boardEl.getBoundingClientRect();
         const x = Math.min(Math.max(0, e.clientX - rect.left), rect.width - 0.01);
         const y = Math.min(Math.max(0, e.clientY - rect.top), rect.height - 0.01);
-        const col = Math.floor((x / rect.width) * 8);
-        const row = Math.floor((y / rect.height) * 8);
-        const sq = cellSquare(row, col);
+        let col = Math.floor((x / rect.width) * 8);
+        let row = Math.floor((y / rect.height) * 8);
+        const sq = cellSquare(row, col); // uses playerColor for orientation
 
         console.log('Click at row:', row, 'col:', col, 'square:', sq);
 


### PR DESCRIPTION
## Summary
- add `playerColor` query parameter and variable to choose board orientation
- flip cellSquare and FEN rendering when playing as black
- map click coordinates through orientation-aware square lookup

## Testing
- `go test ./...` *(fails: command hung)*

------
https://chatgpt.com/codex/tasks/task_e_68be4b8f81608320b795ae868720020a