### PR TITLE
Use Clients map for player color lookup

### DIFF
--- a/internal/handlers/handle_move_test.go
+++ b/internal/handlers/handle_move_test.go
@@ -15,8 +15,8 @@ import (
 func TestHandleMoveWrongColor(t *testing.T) {
 	hub := game.NewHub()
 	h := NewHandler(hub)
-	g := hub.Get("g1")
-	g.Seats["c1"] = chess.White
+	g := hub.Get("g1", "")
+	g.Clients["c1"] = chess.White
 
 	req := httptest.NewRequest("POST", "/move/g1", strings.NewReader(`{"uci":"a7a6","clientId":"c1"}`))
 	w := httptest.NewRecorder()
@@ -35,8 +35,8 @@ func TestHandleMoveWrongColor(t *testing.T) {
 func TestHandleMoveNotYourTurn(t *testing.T) {
 	hub := game.NewHub()
 	h := NewHandler(hub)
-	g := hub.Get("g2")
-	g.Seats["c2"] = chess.Black
+	g := hub.Get("g2", "")
+	g.Clients["c2"] = chess.Black
 
 	req := httptest.NewRequest("POST", "/move/g2", strings.NewReader(`{"uci":"a7a6","clientId":"c2"}`))
 	w := httptest.NewRecorder()
@@ -55,8 +55,8 @@ func TestHandleMoveNotYourTurn(t *testing.T) {
 func TestHandleMoveSuccess(t *testing.T) {
 	hub := game.NewHub()
 	h := NewHandler(hub)
-	g := hub.Get("g3")
-	g.Seats["c1"] = chess.White
+	g := hub.Get("g3", "")
+	g.Clients["c1"] = chess.White
 
 	req := httptest.NewRequest("POST", "/move/g3", strings.NewReader(`{"uci":"e2e4","clientId":"c1"}`))
 	w := httptest.NewRecorder()

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -124,7 +124,7 @@ func (h *Handler) HandleMove(w http.ResponseWriter, r *http.Request) {
 
 	g.Mu.Lock()
 	state := g.StateLocked()
-	playerColor, ok := g.Seats[clientID]
+	playerColor, ok := g.Clients[clientID]
 	g.Mu.Unlock()
 
 	fenOpt, err := chess.FEN(state.FEN)


### PR DESCRIPTION
## Summary
- resolve player color in move handler using Clients map instead of deprecated Seats map
- align handler tests with Clients map and updated Hub.Get signature

## Testing
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68be51ee16cc832083e9b0e7c38f0aa1