### PR TITLE
Include client color in initial SSE state

### DIFF
--- a/internal/game/types.go
+++ b/internal/game/types.go
@@ -49,6 +49,12 @@ type GameState struct {
 	Watchers int      `json:"watchers"`
 }
 
+// ClientState represents the state sent to a specific client, including their color
+type ClientState struct {
+	GameState
+	Color string `json:"color,omitempty"`
+}
+
 // ReactionPayload represents a reaction broadcast
 type ReactionPayload struct {
 	Kind   string `json:"kind"`

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -62,10 +62,17 @@ func (h *Handler) HandleSSE(w http.ResponseWriter, r *http.Request) {
 	g.AddWatcher(ch)
 
 	g.Mu.Lock()
-	initial, _ := json.Marshal(g.StateLocked())
+	state := g.StateLocked()
+	col, exists := g.Clients[clientID]
 	g.Mu.Unlock()
 
-	_, _ = fmt.Fprintf(w, "data: %s\n\n", initial)
+	initial := game.ClientState{GameState: state}
+	if exists {
+		initial.Color = col.String()
+	}
+	initialJSON, _ := json.Marshal(initial)
+
+	_, _ = fmt.Fprintf(w, "data: %s\n\n", initialJSON)
 	flusher.Flush()
 
 	g.Touch()

--- a/internal/templates/game.html
+++ b/internal/templates/game.html
@@ -429,9 +429,9 @@
       const reactBar = document.getElementById('reactbar');
       gameIdEl.textContent = gameId || '(none)';
 
-      // Orientation (default white, ?color=black flips board)
-      const params = new URLSearchParams(location.search);
-      const playerColor = params.get('color') === 'black' ? 'black' : 'white';
+      // Orientation (default white; updated from server message)
+      let playerColor = 'white';
+      let playerColorSet = false;
 
       // Theme picker
       const root = document.documentElement;
@@ -788,6 +788,10 @@
             return;
           }
           if (st.kind === 'state') {
+            if (!playerColorSet && st.color) {
+              playerColor = st.color;
+              playerColorSet = true;
+            }
             lastMoveSquares = deriveLastMoveSquares(st.uci || []);
             renderFEN(st.fen);
             turnEl.textContent = st.turn || '';


### PR DESCRIPTION
## Summary
- Add `ClientState` struct carrying a player's color
- Send player's color in initial SSE payload and use it in frontend
- Set board orientation from SSE color and remove query-param logic

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68be5534fc188320933c16c6fc709a31