### PR TITLE
Open version link in new tab and inherit theme colors

### DIFF
--- a/internal/templates/game.html
+++ b/internal/templates/game.html
@@ -226,6 +226,11 @@
       font-size: 12px;
     }
 
+    footer .version a,
+    footer .version a:visited {
+      color: inherit;
+    }
+
     .theme {
       display: flex;
       gap: 6px;
@@ -397,7 +402,7 @@
   </div>
   <footer>
     Built with Go, SSE & vanilla JS — with ❤️ by Dusty and his traumatized 🤖
-    <div class="version">Version: <a href="https://github.com/dustywusty/tinychess/tree/{{COMMIT}}">{{COMMIT}}</a></div>
+    <div class="version">Version: <a href="https://github.com/dustywusty/tinychess/tree/{{COMMIT}}" target="_blank" rel="noopener">{{COMMIT}}</a></div>
   </footer>
   <script defer data-domain="tinychess.bitchimfabulo.us"
     src="https://plausible.io/js/script.outbound-links.js"></script>

--- a/internal/templates/home.html
+++ b/internal/templates/home.html
@@ -149,6 +149,11 @@
       font-size: 12px;
     }
 
+    footer .version a,
+    footer .version a:visited {
+      color: inherit;
+    }
+
     /* Recent list */
     .recent {
       max-width: 800px;
@@ -216,7 +221,7 @@
 
   <footer>
     Built with Go, SSE & vanilla JS — with ❤️ by Dusty and his traumatized 🤖
-    <div class="version">Version: <a href="https://github.com/dustywusty/tinychess/tree/{{COMMIT}}">{{COMMIT}}</a></div>
+    <div class="version">Version: <a href="https://github.com/dustywusty/tinychess/tree/{{COMMIT}}" target="_blank" rel="noopener">{{COMMIT}}</a></div>
   </footer>
   <script defer data-domain="tinychess.bitchimfabulo.us"
     src="https://plausible.io/js/script.outbound-links.js"></script>


### PR DESCRIPTION
## Summary
- Open version links in a new tab
- Style version links to inherit theme text color

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68be56f23a58832084072944f5390a28