### PR TITLE
Handle spectators

### DIFF
--- a/internal/game/hub.go
+++ b/internal/game/hub.go
@@ -65,13 +65,15 @@ func (h *Hub) Get(id, clientId string) *Game {
 			g.OwnerID = clientId
 			g.Clients[clientId] = g.OwnerColor
 		} else if _, exists := g.Clients[clientId]; !exists {
-			var color chess.Color
-			if g.OwnerColor == chess.White {
-				color = chess.Black
-			} else {
-				color = chess.White
+			if len(g.Clients) < 2 {
+				var color chess.Color
+				if g.OwnerColor == chess.White {
+					color = chess.Black
+				} else {
+					color = chess.White
+				}
+				g.Clients[clientId] = color
 			}
-			g.Clients[clientId] = color
 		}
 		g.Mu.Unlock()
 	}

--- a/internal/game/types.go
+++ b/internal/game/types.go
@@ -52,7 +52,8 @@ type GameState struct {
 // ClientState represents the state sent to a specific client, including their color
 type ClientState struct {
 	GameState
-	Color string `json:"color,omitempty"`
+	Color *string `json:"color"`
+	Role  string  `json:"role"`
 }
 
 // ReactionPayload represents a reaction broadcast

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -66,9 +66,11 @@ func (h *Handler) HandleSSE(w http.ResponseWriter, r *http.Request) {
 	col, exists := g.Clients[clientID]
 	g.Mu.Unlock()
 
-	initial := game.ClientState{GameState: state}
+	initial := game.ClientState{GameState: state, Role: "spectator"}
 	if exists {
-		initial.Color = col.String()
+		c := col.String()
+		initial.Color = &c
+		initial.Role = "player"
 	}
 	initialJSON, _ := json.Marshal(initial)
 

--- a/internal/templates/game.html
+++ b/internal/templates/game.html
@@ -373,6 +373,7 @@
     <div class="board" id="board" aria-label="Chess board"></div>
     <div class="panel">
       <div class="row"><strong>Game:</strong> <span id="gameid" class="mono"></span></div>
+      <div class="row"><strong>You:</strong> <span id="role"></span></div>
       <div class="row"><strong>Turn:</strong> <span id="turn"></span></div>
       <div class="status" id="status"></div>
 
@@ -428,6 +429,7 @@
       const pgnEl = document.getElementById('pgn');
       const lanEl = document.getElementById('lan');
       const gameIdEl = document.getElementById('gameid');
+      const roleEl = document.getElementById('role');
       const capWhiteEl = document.getElementById('cap_by_white');
       const capBlackEl = document.getElementById('cap_by_black');
       const rxEl = document.getElementById('rx');
@@ -437,6 +439,7 @@
       // Orientation (default white; updated from server message)
       let playerColor = 'white';
       let playerColorSet = false;
+      let isSpectator = false;
 
       // Theme picker
       const root = document.documentElement;
@@ -629,6 +632,7 @@
 
       // Board-level click handler
       boardEl.addEventListener('click', (e) => {
+        if (isSpectator) return;
         const rect = boardEl.getBoundingClientRect();
         const x = Math.min(Math.max(0, e.clientX - rect.left), rect.width - 0.01);
         const y = Math.min(Math.max(0, e.clientY - rect.top), rect.height - 0.01);
@@ -793,10 +797,15 @@
             return;
           }
           if (st.kind === 'state') {
-            if (!playerColorSet && st.color) {
+            if (st.role === 'spectator') {
+              isSpectator = true;
+              playerColor = 'white';
+              playerColorSet = true;
+            } else if (!playerColorSet && st.color) {
               playerColor = st.color;
               playerColorSet = true;
             }
+            if (roleEl) roleEl.textContent = isSpectator ? 'Spectating' : ('Playing as ' + playerColor);
             lastMoveSquares = deriveLastMoveSquares(st.uci || []);
             renderFEN(st.fen);
             turnEl.textContent = st.turn || '';
@@ -819,7 +828,9 @@
               status: st.status || '',
               result: resultFromPGN || (function () { var m = (st.status || '').match(/(1-0|0-1|1\/2-1\/2)/); return m ? m[1] : null; })(),
               finishedAt: finishedNow ? Date.now() : undefined,
-              lastSeen: st.lastSeen
+              lastSeen: st.lastSeen,
+              color: st.color || null,
+              role: st.role || ''
             });
           }
         };


### PR DESCRIPTION
## Summary
- Treat additional clients as spectators once both colors are occupied
- Include color and role in SSE client state
- Frontend shows playing/spectating status and blocks moves for spectators

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68be5b28400c832099c0520a94a09d1f