### PR TITLE
test: ensure color assignment

### DIFF
--- a/internal/game/hub_test.go
+++ b/internal/game/hub_test.go
@@ -77,3 +77,24 @@ func TestOwnerAndClientColorAssignment(t *testing.T) {
 		t.Fatalf("expected client2 color %v, got %v", expected, c)
 	}
 }
+
+func TestTwoClientsReceiveOppositeColors(t *testing.T) {
+	h := NewHub()
+	g := h.Get("g2", "c1")
+	g = h.Get("g2", "c2")
+
+	c1 := g.Clients["c1"]
+	c2 := g.Clients["c2"]
+
+	if (c1 != chess.White && c1 != chess.Black) || (c2 != chess.White && c2 != chess.Black) {
+		t.Fatalf("clients received invalid colors: %v and %v", c1, c2)
+	}
+	if c1 == c2 {
+		t.Fatalf("expected clients to have opposite colors, both got %v", c1)
+	}
+
+	g = h.Get("g2", "")
+	if len(g.Clients) != 2 {
+		t.Fatalf("spectator should not be assigned a color")
+	}
+}


### PR DESCRIPTION
## Summary
- add regression test ensuring two clients to same game get opposing colors
- verify a spectator connection does not receive a color assignment

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68be5c5b70ec8320aee3848b63678f78