### PR TITLE
Assign colors on SSE and expose client IDs

### DIFF
--- a/internal/game/get_color_test.go
+++ b/internal/game/get_color_test.go
@@ -1,0 +1,22 @@
+package game
+
+import "testing"
+
+func TestGetReturnsAssignedColor(t *testing.T) {
+	h := NewHub()
+	_, c1 := h.Get("g", "c1")
+	if c1 == nil {
+		t.Fatalf("expected color for first client")
+	}
+	_, c2 := h.Get("g", "c2")
+	if c2 == nil {
+		t.Fatalf("expected color for second client")
+	}
+	if *c1 == *c2 {
+		t.Fatalf("expected different colors, got %v and %v", *c1, *c2)
+	}
+	_, c3 := h.Get("g", "c3")
+	if c3 != nil {
+		t.Fatalf("expected spectator for third client")
+	}
+}

--- a/internal/game/hub_test.go
+++ b/internal/game/hub_test.go
@@ -23,7 +23,7 @@ func runCleanup(h *Hub) {
 
 func TestGamePersistenceBeforeCleanup(t *testing.T) {
 	h := NewHub()
-	g := h.Get("test", "")
+	g, _ := h.Get("test", "")
 
 	// Simulate a game that was last seen 23 hours ago.
 	g.Mu.Lock()
@@ -56,7 +56,7 @@ func TestGamePersistenceBeforeCleanup(t *testing.T) {
 
 func TestOwnerAndClientColorAssignment(t *testing.T) {
 	h := NewHub()
-	g := h.Get("g1", "owner")
+	g, _ := h.Get("g1", "owner")
 
 	if g.OwnerID != "owner" {
 		t.Fatalf("expected owner id to be set")
@@ -66,7 +66,7 @@ func TestOwnerAndClientColorAssignment(t *testing.T) {
 		t.Fatalf("owner not recorded with correct color")
 	}
 
-	g = h.Get("g1", "client2")
+	g, _ = h.Get("g1", "client2")
 	var expected chess.Color
 	if ownerColor == chess.White {
 		expected = chess.Black
@@ -80,8 +80,8 @@ func TestOwnerAndClientColorAssignment(t *testing.T) {
 
 func TestTwoClientsReceiveOppositeColors(t *testing.T) {
 	h := NewHub()
-	g := h.Get("g2", "c1")
-	g = h.Get("g2", "c2")
+	g, _ := h.Get("g2", "c1")
+	g, _ = h.Get("g2", "c2")
 
 	c1 := g.Clients["c1"]
 	c2 := g.Clients["c2"]
@@ -93,7 +93,7 @@ func TestTwoClientsReceiveOppositeColors(t *testing.T) {
 		t.Fatalf("expected clients to have opposite colors, both got %v", c1)
 	}
 
-	g = h.Get("g2", "")
+	g, _ = h.Get("g2", "")
 	if len(g.Clients) != 2 {
 		t.Fatalf("spectator should not be assigned a color")
 	}

--- a/internal/game/types.go
+++ b/internal/game/types.go
@@ -52,8 +52,9 @@ type GameState struct {
 // ClientState represents the state sent to a specific client, including their color
 type ClientState struct {
 	GameState
-	Color *string `json:"color"`
-	Role  string  `json:"role"`
+	Color    *string `json:"color"`
+	Role     string  `json:"role"`
+	ClientID string  `json:"clientId"`
 }
 
 // ReactionPayload represents a reaction broadcast

--- a/internal/handlers/handle_move_test.go
+++ b/internal/handlers/handle_move_test.go
@@ -15,7 +15,7 @@ import (
 func TestHandleMoveWrongColor(t *testing.T) {
 	hub := game.NewHub()
 	h := NewHandler(hub)
-	g := hub.Get("g1", "")
+	g, _ := hub.Get("g1", "")
 	g.Clients["c1"] = chess.White
 
 	req := httptest.NewRequest("POST", "/move/g1", strings.NewReader(`{"uci":"a7a6","clientId":"c1"}`))
@@ -35,7 +35,7 @@ func TestHandleMoveWrongColor(t *testing.T) {
 func TestHandleMoveNotYourTurn(t *testing.T) {
 	hub := game.NewHub()
 	h := NewHandler(hub)
-	g := hub.Get("g2", "")
+	g, _ := hub.Get("g2", "")
 	g.Clients["c2"] = chess.Black
 
 	req := httptest.NewRequest("POST", "/move/g2", strings.NewReader(`{"uci":"a7a6","clientId":"c2"}`))
@@ -55,7 +55,7 @@ func TestHandleMoveNotYourTurn(t *testing.T) {
 func TestHandleMoveSuccess(t *testing.T) {
 	hub := game.NewHub()
 	h := NewHandler(hub)
-	g := hub.Get("g3", "")
+	g, _ := hub.Get("g3", "")
 	g.Clients["c1"] = chess.White
 
 	req := httptest.NewRequest("POST", "/move/g3", strings.NewReader(`{"uci":"e2e4","clientId":"c1"}`))

--- a/internal/handlers/middleware_test.go
+++ b/internal/handlers/middleware_test.go
@@ -8,7 +8,8 @@ import (
 
 func newGame() *game.Game {
 	hub := game.NewHub()
-	return hub.Get("test", "")
+	g, _ := hub.Get("test", "")
+	return g
 }
 
 func TestAppendPromotionIfPawnRank8(t *testing.T) {

--- a/internal/templates/game.html
+++ b/internal/templates/game.html
@@ -413,11 +413,7 @@
 
       // ---- IDs / elements ----
       const CLIENT_ID_KEY = "tinychess:clientId";
-      let clientId = localStorage.getItem(CLIENT_ID_KEY);
-      if (!clientId) {
-        clientId = Math.random().toString(36).slice(2);
-        localStorage.setItem(CLIENT_ID_KEY, clientId);
-      }
+      let clientId = sessionStorage.getItem(CLIENT_ID_KEY) || '';
       // If the server didn't substitute {{GAME_ID}}, fall back to the path.
       const idFromServerRaw = "{{GAME_ID}}";
       const gameId = (idFromServerRaw && idFromServerRaw !== "{{GAME_ID}}")
@@ -789,7 +785,9 @@
       status('');
 
       if (gameId) {
-        const es = new EventSource('/sse/' + gameId + '?clientId=' + encodeURIComponent(clientId));
+        let sseURL = '/sse/' + gameId;
+        if (clientId) sseURL += '?clientId=' + encodeURIComponent(clientId);
+        const es = new EventSource(sseURL);
         es.onmessage = (ev) => {
           const st = JSON.parse(ev.data || "{}");
           if (st.kind === 'emoji') {
@@ -797,12 +795,15 @@
             return;
           }
           if (st.kind === 'state') {
+            if (!clientId && st.clientId) {
+              clientId = st.clientId;
+              try { sessionStorage.setItem(CLIENT_ID_KEY, clientId); } catch {}
+            }
             if (st.role === 'spectator') {
               isSpectator = true;
-              playerColor = 'white';
-              playerColorSet = true;
-            } else if (!playerColorSet && st.color) {
-              playerColor = st.color;
+            }
+            if (!playerColorSet) {
+              playerColor = st.color || 'white';
               playerColorSet = true;
             }
             if (roleEl) roleEl.textContent = isSpectator ? 'Spectating' : ('Playing as ' + playerColor);


### PR DESCRIPTION
## Summary
- generate a new client ID when SSE requests omit one and include it in initial payload
- return and transmit assigned player colors, treating extra connections as spectators
- orient board from received color using session-scoped client IDs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68be603919c88320825e5a9ae75fa8d9