### PR TITLE
Fix board orientation by normalizing player color

### DIFF
--- a/internal/templates/game.html
+++ b/internal/templates/game.html
@@ -437,6 +437,14 @@
       let playerColorSet = false;
       let isSpectator = false;
 
+      function normalizeColor(c) {
+        if (!c) return 'white';
+        const v = String(c).toLowerCase();
+        if (v === 'w' || v === 'white') return 'white';
+        if (v === 'b' || v === 'black') return 'black';
+        return 'white';
+      }
+
       // Theme picker
       const root = document.documentElement;
       let theme = localStorage.getItem('theme') || 'dark';
@@ -803,10 +811,10 @@
               isSpectator = true;
             }
             if (!playerColorSet) {
-              playerColor = st.color || 'white';
+              playerColor = normalizeColor(st.color);
               playerColorSet = true;
             }
-            if (roleEl) roleEl.textContent = isSpectator ? 'Spectating' : ('Playing as ' + playerColor);
+            if (roleEl) roleEl.textContent = isSpectator ? 'Spectating' : ('Playing as ' + playerColor.charAt(0).toUpperCase() + playerColor.slice(1));
             lastMoveSquares = deriveLastMoveSquares(st.uci || []);
             renderFEN(st.fen);
             turnEl.textContent = st.turn || '';
@@ -830,7 +838,7 @@
               result: resultFromPGN || (function () { var m = (st.status || '').match(/(1-0|0-1|1\/2-1\/2)/); return m ? m[1] : null; })(),
               finishedAt: finishedNow ? Date.now() : undefined,
               lastSeen: st.lastSeen,
-              color: st.color || null,
+              color: st.color ? normalizeColor(st.color) : null,
               role: st.role || ''
             });
           }


### PR DESCRIPTION
## Summary
- Normalize server color codes so boards orient correctly for each player
- Persist normalized color and improve role display

## Testing
- `go test ./... && echo DONE`


------
https://chatgpt.com/codex/tasks/task_e_68be6662c5dc83209c90de8da4194075