### PR TITLE
Allow game owners to release player seats

### DIFF
--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -100,6 +100,17 @@ func (g *Game) RemoveWatcher(ch chan []byte) {
 	g.Mu.Unlock()
 }
 
+// RemoveClient removes a client from the game. If the client was the owner,
+// the owner slot is cleared so another client can claim it later.
+func (g *Game) RemoveClient(id string) {
+	g.Mu.Lock()
+	delete(g.Clients, id)
+	if g.OwnerID == id {
+		g.OwnerID = ""
+	}
+	g.Mu.Unlock()
+}
+
 // CanReact checks if a sender can send a reaction (cooldown check)
 func (g *Game) CanReact(sender string) (bool, int) {
 	g.Mu.Lock()

--- a/internal/game/remove_client_test.go
+++ b/internal/game/remove_client_test.go
@@ -1,0 +1,33 @@
+package game
+
+import (
+	"testing"
+
+	"github.com/notnil/chess"
+)
+
+func TestRemoveClient(t *testing.T) {
+	g := &Game{
+		Clients:    make(map[string]chess.Color),
+		OwnerID:    "owner",
+		OwnerColor: chess.White,
+	}
+	g.Clients["owner"] = chess.White
+	g.Clients["other"] = chess.Black
+
+	g.RemoveClient("other")
+	if _, ok := g.Clients["other"]; ok {
+		t.Fatalf("expected other client to be removed")
+	}
+	if g.OwnerID != "owner" {
+		t.Fatalf("owner id should remain unchanged")
+	}
+
+	g.RemoveClient("owner")
+	if g.OwnerID != "" {
+		t.Fatalf("owner id should be cleared when owner removed")
+	}
+	if _, ok := g.Clients["owner"]; ok {
+		t.Fatalf("owner should be removed from clients map")
+	}
+}

--- a/internal/handlers/handle_release_test.go
+++ b/internal/handlers/handle_release_test.go
@@ -1,0 +1,56 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"tinychess/internal/game"
+
+	"github.com/notnil/chess"
+)
+
+func TestHandleRelease(t *testing.T) {
+	hub := game.NewHub()
+	h := NewHandler(hub)
+	g, _ := hub.Get("g1", "owner")
+	g.Clients["other"] = chess.Black
+
+	req := httptest.NewRequest("POST", "/release/g1", strings.NewReader(`{"clientId":"owner","targetId":"other"}`))
+	w := httptest.NewRecorder()
+	h.HandleRelease(w, req)
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp["ok"].(bool) {
+		t.Fatalf("expected ok true")
+	}
+	if _, exists := g.Clients["other"]; exists {
+		t.Fatalf("expected client to be removed")
+	}
+}
+
+func TestHandleReleaseNotOwner(t *testing.T) {
+	hub := game.NewHub()
+	h := NewHandler(hub)
+	g, _ := hub.Get("g2", "owner")
+	g.Clients["other"] = chess.Black
+
+	req := httptest.NewRequest("POST", "/release/g2", strings.NewReader(`{"clientId":"notowner","targetId":"other"}`))
+	w := httptest.NewRecorder()
+	h.HandleRelease(w, req)
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["ok"].(bool) {
+		t.Fatalf("expected ok false")
+	}
+	if _, exists := g.Clients["other"]; !exists {
+		t.Fatalf("client should still be present")
+	}
+}

--- a/internal/templates/home.html
+++ b/internal/templates/home.html
@@ -211,6 +211,7 @@
   <main>
     <h1>Play chess with a link</h1>
     <p>Click "New game" to create a shareable URL. Anyone with the link can watch and move.</p>
+    <p>When you start a game you play White and own the board. The next person to visit joins as the opponent; everyone else who opens the link is a spectator.</p>
     <p><a class="btn" href="/new" id="newgame2">New game</a></p>
   </main>
 

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ func main() {
 	http.HandleFunc("/sse/", h.HandleSSE)
 	http.HandleFunc("/move/", h.HandleMove)
 	http.HandleFunc("/react/", h.HandleReact)
+	http.HandleFunc("/release/", h.HandleRelease)
 	http.HandleFunc("/reset/", h.HandleReset)
 	http.HandleFunc("/", h.HandlePage)
 


### PR DESCRIPTION
## Summary
- Let a game owner remove a player's client ID to free up the seat
- Add HTTP `/release/{id}` endpoint and route
- Cover seat release with unit tests
- Explain game flow on the home page so creators and spectators know their roles

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68be6a1e0c6c83209741c98f1eb6fa32