### PR TITLE
Preserve player color across refresh after owner release

### DIFF
--- a/internal/game/hub.go
+++ b/internal/game/hub.go
@@ -65,13 +65,17 @@ func (h *Hub) Get(id, clientId string) (*Game, *chess.Color) {
 
 	if clientId != "" {
 		g.Mu.Lock()
-		if g.OwnerID == "" {
+		if col, exists := g.Clients[clientId]; exists {
+			if g.OwnerID == "" {
+				g.OwnerID = clientId
+				g.OwnerColor = col
+			}
+			c := col
+			assigned = &c
+		} else if g.OwnerID == "" {
 			g.OwnerID = clientId
 			g.Clients[clientId] = g.OwnerColor
 			c := g.OwnerColor
-			assigned = &c
-		} else if col, exists := g.Clients[clientId]; exists {
-			c := col
 			assigned = &c
 		} else if len(g.Clients) < 2 {
 			var color chess.Color

--- a/internal/game/hub_test.go
+++ b/internal/game/hub_test.go
@@ -98,3 +98,37 @@ func TestTwoClientsReceiveOppositeColors(t *testing.T) {
 		t.Fatalf("spectator should not be assigned a color")
 	}
 }
+
+func TestColorPersistsAfterOwnerLeaves(t *testing.T) {
+	h := NewHub()
+
+	// owner joins
+	g, _ := h.Get("g3", "owner")
+	// second player joins
+	g, _ = h.Get("g3", "player")
+
+	initialColor := g.Clients["player"]
+
+	// owner releases themselves
+	g.RemoveClient("owner")
+
+	// player refreshes (rejoins)
+	g, col := h.Get("g3", "player")
+	if col == nil || *col != initialColor {
+		t.Fatalf("expected player to retain color %v, got %v", initialColor, col)
+	}
+
+	if g.OwnerID != "player" {
+		t.Fatalf("expected player to become owner after release")
+	}
+
+	if g.OwnerColor != initialColor {
+		t.Fatalf("owner color not updated to player's color")
+	}
+
+	// new client should receive opposite color
+	g, col2 := h.Get("g3", "newbie")
+	if col2 == nil || *col2 == initialColor {
+		t.Fatalf("expected new client to receive opposite color")
+	}
+}


### PR DESCRIPTION
## Summary
- ensure existing players keep their assigned color when the owner slot is open
- update owner color when ownership transfers
- cover color persistence with tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68be7fac9ddc83209c71eead3564fa74