### PR TITLE
Improve turn handling and capture feedback

### DIFF
--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -1,6 +1,7 @@
 package game
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -34,5 +35,24 @@ func TestMakeMoveInvalidUCI(t *testing.T) {
 	g := newTestGame()
 	if err := g.MakeMove("invalid"); err == nil {
 		t.Fatalf("expected error for invalid UCI, got nil")
+	}
+}
+
+func TestCheckmateState(t *testing.T) {
+	g := newTestGame()
+	moves := []string{"f2f3", "e7e5", "g2g4", "d8h4"}
+	for _, m := range moves {
+		if err := g.MakeMove(m); err != nil {
+			t.Fatalf("move %s failed: %v", m, err)
+		}
+	}
+	g.Mu.Lock()
+	st := g.StateLocked()
+	g.Mu.Unlock()
+	if st.Status == "" {
+		t.Fatalf("expected status to be set after checkmate")
+	}
+	if !strings.Contains(strings.ToLower(st.Status), "checkmate") {
+		t.Fatalf("expected checkmate in status, got %s", st.Status)
 	}
 }

--- a/internal/templates/game.html
+++ b/internal/templates/game.html
@@ -272,6 +272,12 @@
         line-height: 1;
       }
 
+      .caps span.recent {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+        border-radius: 4px;
+      }
+
       .reactions {
         display: flex;
         gap: 6px;
@@ -486,6 +492,8 @@
         let playerColor = "white";
         let playerColorSet = false;
         let isSpectator = false;
+        let gameOver = false;
+        let prevCaptured = { byWhite: [], byBlack: [] };
 
         function normalizeColor(c) {
           if (!c) return "white";
@@ -799,7 +807,7 @@
 
         // Board-level click handler
         boardEl.addEventListener("click", (e) => {
-          if (isSpectator) return;
+          if (isSpectator || gameOver) return;
           const rect = boardEl.getBoundingClientRect();
           const x = Math.min(
             Math.max(0, e.clientX - rect.left),
@@ -837,6 +845,22 @@
         function status(msg, isErr) {
           statusEl.textContent = msg || "";
           statusEl.style.color = isErr ? "var(--err)" : "inherit";
+        }
+
+        function updateTurn(st) {
+          if (!turnEl) return;
+          if (st.status) {
+            turnEl.textContent = "Game over";
+            return;
+          }
+          const t = normalizeColor(st.turn);
+          if (isSpectator) {
+            turnEl.textContent = t || "";
+          } else if (t === playerColor) {
+            turnEl.textContent = "Your turn";
+          } else {
+            turnEl.textContent = "Their turn";
+          }
         }
 
         // ---- Captured pieces (derived from FEN) + persisted per game ----
@@ -947,13 +971,19 @@
           for (var i = 0; i < byWhite.length; i++) {
             var s1 = document.createElement("span");
             s1.textContent = byWhite[i];
+            s1.classList.add("black-piece");
+            if (i >= prevCaptured.byWhite.length) s1.classList.add("recent");
             capWhiteEl.appendChild(s1);
           }
           for (var j = 0; j < byBlack.length; j++) {
             var s2 = document.createElement("span");
             s2.textContent = byBlack[j];
+            s2.classList.add("white-piece");
+            if (j >= prevCaptured.byBlack.length) s2.classList.add("recent");
             capBlackEl.appendChild(s2);
           }
+          prevCaptured.byWhite = byWhite.slice();
+          prevCaptured.byBlack = byBlack.slice();
         }
 
         function capKey(id) {
@@ -1058,7 +1088,7 @@
 
         // Render start position immediately (prevents blank board)
         renderFEN(START_FEN);
-        turnEl.textContent = "white";
+        turnEl.textContent = "";
         status("");
 
         if (gameId) {
@@ -1095,10 +1125,11 @@
                 releaseBtn.style.display = isSpectator ? "none" : "";
               lastMoveSquares = deriveLastMoveSquares(st.uci || []);
               renderFEN(st.fen);
-              turnEl.textContent = st.turn || "";
+              updateTurn(st);
               pgnEl.textContent = formatPGNLines(st.pgn || "");
               lanEl.textContent = formatUCIMoves(st.uci || []);
               status(st.status || "");
+              gameOver = !!st.status;
               const caps = capturedFromFEN(st.fen);
               renderCaptured(caps.byWhite, caps.byBlack);
               try {
@@ -1129,6 +1160,9 @@
                 role: st.role || "",
               });
             }
+          };
+          es.onopen = () => {
+            status("");
           };
           es.onerror = () => {
             status("Disconnected. Reconnecting…", true);


### PR DESCRIPTION
## Summary
- show "Your turn"/"Their turn" and clear reconnect notices
- color and highlight captured pieces for the last capture
- add regression test ensuring checkmate is reported

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c13f2aa05083208ac7a181ad95704f