### PR TITLE
Add build date to version banner

### DIFF
--- a/internal/templates/game.html
+++ b/internal/templates/game.html
@@ -454,6 +454,7 @@
           rel="noopener"
           >{{COMMIT}}</a
         >
+        ({{BUILD_DATE}})
       </div>
     </footer>
     <script

--- a/internal/templates/home.html
+++ b/internal/templates/home.html
@@ -271,6 +271,7 @@
           rel="noopener"
           >{{COMMIT}}</a
         >
+        ({{BUILD_DATE}})
       </div>
     </footer>
     <script

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -8,8 +8,12 @@ import (
 )
 
 var commit = "dev"
+var buildDate = ""
 
-func SetCommit(c string) { commit = c }
+func SetVersion(c, d string) {
+	commit = c
+	buildDate = d
+}
 
 // WriteHomeHTML serves the home page template
 func WriteHomeHTML(w http.ResponseWriter) {
@@ -23,6 +27,7 @@ func WriteHomeHTML(w http.ResponseWriter) {
 		return
 	}
 	html := strings.ReplaceAll(string(content), "{{COMMIT}}", commit)
+	html = strings.ReplaceAll(html, "{{BUILD_DATE}}", buildDate)
 	_, _ = w.Write([]byte(html))
 }
 
@@ -40,6 +45,7 @@ func WriteGameHTML(w http.ResponseWriter, gameID string) {
 
 	html := strings.ReplaceAll(string(content), "{{GAME_ID}}", gameID)
 	html = strings.ReplaceAll(html, "{{COMMIT}}", commit)
+	html = strings.ReplaceAll(html, "{{BUILD_DATE}}", buildDate)
 	_, _ = w.Write([]byte(html))
 }
 

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ func main() {
 	flag.Parse()
 	logging.Debug = *debug
 
-	templates.SetCommit(commit)
+	templates.SetVersion(commit, buildDate)
 
 	if dsn := os.Getenv("DATABASE_URL"); dsn != "" {
 		if _, err := storage.New(dsn); err != nil {


### PR DESCRIPTION
## Summary
- compute build date from build metadata
- show build date next to commit in version banner
- pass commit and date into templates

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c6969e98888320aeb65546bf036bfd