### PR TITLE
Fix repeated schema creation by disabling prepared statements

### DIFF
--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -7,7 +7,10 @@ import (
 
 // New initializes the database connection and performs migrations.
 func New(dsn string) (*gorm.DB, error) {
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	db, err := gorm.Open(postgres.New(postgres.Config{
+		DSN:                  dsn,
+		PreferSimpleProtocol: true,
+	}), &gorm.Config{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- use pgx's simple protocol to avoid prepared statement reuse that caused migration to attempt recreating tables

## Testing
- `go test ./... -v`


------
https://chatgpt.com/codex/tasks/task_e_68c773ddc92483209b3284418fe09d82