### PR TITLE
Reorder board and simplify footer

### DIFF
--- a/internal/templates/game.html
+++ b/internal/templates/game.html
@@ -224,15 +224,6 @@
         text-align: center;
       }
 
-      footer .version {
-        margin-top: 4px;
-        font-size: 12px;
-      }
-
-      footer .version a,
-      footer .version a:visited {
-        color: inherit;
-      }
 
       .theme {
         display: flex;
@@ -400,6 +391,7 @@
     </header>
 
     <div class="wrap">
+      <div class="board" id="board" aria-label="Chess board"></div>
       <div class="panel">
         <div class="row">
           <strong>Game:</strong> <span id="gameid" class="mono"></span>
@@ -433,23 +425,13 @@
           <pre id="pgn" style="white-space: pre-wrap"></pre>
         </details>
       </div>
-      <div class="board" id="board" aria-label="Chess board"></div>
     </div>
     <dialog id="emojiDialog">
       <emoji-picker id="emojiPicker"></emoji-picker>
     </dialog>
     <footer>
-      Built with Go & vanilla JS — with ❤️ by Dusty and his traumatized 🤖
-      <div class="version">
-        Version:
-        <a
-          href="https://github.com/dustywusty/tinychess/tree/{{COMMIT}}"
-          target="_blank"
-          rel="noopener"
-          >{{COMMIT}}</a
-        >
-        ({{BUILD_DATE}})
-      </div>
+      Version: {{COMMIT}}<br />
+      Built-on: {{BUILD_DATE}}
     </footer>
     <script
       defer

--- a/internal/templates/home.html
+++ b/internal/templates/home.html
@@ -144,15 +144,6 @@
         text-align: center;
       }
 
-      footer .version {
-        margin-top: 4px;
-        font-size: 12px;
-      }
-
-      footer .version a,
-      footer .version a:visited {
-        color: inherit;
-      }
 
       /* Recent list */
       .recent {
@@ -262,17 +253,8 @@
     </section>
 
     <footer>
-      Built with Go & vanilla JS — with ❤️ by Dusty and his traumatized 🤖
-      <div class="version">
-        Version:
-        <a
-          href="https://github.com/dustywusty/tinychess/tree/{{COMMIT}}"
-          target="_blank"
-          rel="noopener"
-          >{{COMMIT}}</a
-        >
-        ({{BUILD_DATE}})
-      </div>
+      Version: {{COMMIT}}<br />
+      Built-on: {{BUILD_DATE}}
     </footer>
     <script
       defer

--- a/version.go
+++ b/version.go
@@ -23,9 +23,9 @@ func init() {
 				}
 			case "vcs.time":
 				if buildDate == "" && s.Value != "" {
-					if t, err := time.Parse(time.RFC3339, s.Value); err == nil {
-						buildDate = t.Format("1-2-2006")
-					}
+                                        if t, err := time.Parse(time.RFC3339, s.Value); err == nil {
+                                                buildDate = t.Format("01-02-2006")
+                                        }
 				}
 			}
 		}
@@ -35,7 +35,7 @@ func init() {
 			commit = strings.TrimSpace(string(c))
 		}
 	}
-	if buildDate == "" {
-		buildDate = time.Now().Format("1-2-2006")
-	}
+        if buildDate == "" {
+                buildDate = time.Now().Format("01-02-2006")
+        }
 }


### PR DESCRIPTION
## Summary
- display chessboard above status panel on game page
- streamline footer to show version and build date
- format build date as MM-DD-YYYY

## Testing
- `go test ./...`
- `make lint` *(fails: ineffassign and staticcheck in internal/game/hub_test.go)*

------
https://chatgpt.com/codex/tasks/task_e_68c775e693b08320be1cad614492e4d7