### PR TITLE
Expand chessboard to full width

### DIFF
--- a/internal/game/hub_test.go
+++ b/internal/game/hub_test.go
@@ -80,8 +80,8 @@ func TestOwnerAndClientColorAssignment(t *testing.T) {
 
 func TestTwoClientsReceiveOppositeColors(t *testing.T) {
 	h := NewHub()
-	g, _ := h.Get("g2", "c1")
-	g, _ = h.Get("g2", "c2")
+	_, _ = h.Get("g2", "c1")
+	g, _ := h.Get("g2", "c2")
 
 	c1 := g.Clients["c1"]
 	c2 := g.Clients["c2"]
@@ -103,9 +103,9 @@ func TestColorPersistsAfterOwnerLeaves(t *testing.T) {
 	h := NewHub()
 
 	// owner joins
-	g, _ := h.Get("g3", "owner")
+	h.Get("g3", "owner")
 	// second player joins
-	g, _ = h.Get("g3", "player")
+	g, _ := h.Get("g3", "player")
 
 	initialColor := g.Clients["player"]
 
@@ -127,7 +127,7 @@ func TestColorPersistsAfterOwnerLeaves(t *testing.T) {
 	}
 
 	// new client should receive opposite color
-	g, col2 := h.Get("g3", "newbie")
+	_, col2 := h.Get("g3", "newbie")
 	if col2 == nil || *col2 == initialColor {
 		t.Fatalf("expected new client to receive opposite color")
 	}

--- a/internal/templates/game.html
+++ b/internal/templates/game.html
@@ -89,8 +89,9 @@
       }
 
       .play {
-        display: inline-flex;
+        display: flex;
         align-items: flex-start;
+        width: 100%;
       }
 
       .moves {
@@ -111,7 +112,7 @@
 
       .board {
         flex: 0 0 auto;
-        width: min(100%, 640px);
+        width: 100%;
         aspect-ratio: 1/1;
         border: 1px solid #2a3345;
         border-radius: 12px;


### PR DESCRIPTION
## Summary
- Make the chessboard fill the available width so it matches the panel
- Clean up tests to fix unused assignments flagged by golangci-lint

## Testing
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c78ad2439483209a89a79fb8ea607e