### PR TITLE
Align board and panel widths, hide empty move list

### DIFF
--- a/internal/templates/game.html
+++ b/internal/templates/game.html
@@ -103,7 +103,7 @@
         border-radius: 12px;
         padding: 8px;
         overflow-y: auto;
-        display: block;
+        display: none;
       }
 
       .moves pre {
@@ -112,8 +112,7 @@
       }
 
       .board {
-        flex: 1 1 auto;
-        width: 100%;
+        flex: 1 1 0;
         aspect-ratio: 1/1;
         border: 1px solid #2a3345;
         border-radius: 12px;


### PR DESCRIPTION
## Summary
- Allow chessboard to flex alongside move list so panel width matches board
- Hide move list until moves exist

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c7e02e5c94832090bacd7aa66b5dd1