### PR TITLE
Persist games in database and surface stats

### DIFF
--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -8,11 +8,13 @@ import (
 	"github.com/corentings/chess/v2"
 )
 
-// Touch updates the last seen timestamp for a game
-func (g *Game) Touch() {
+// Touch updates the last seen timestamp for a game and returns the timestamp.
+func (g *Game) Touch() time.Time {
+	now := time.Now()
 	g.Mu.Lock()
-	g.LastSeen = time.Now()
+	g.LastSeen = now
 	g.Mu.Unlock()
+	return now
 }
 
 // MovesUCI returns the list of moves in UCI notation
@@ -140,4 +142,11 @@ func (g *Game) BroadcastReaction(payload ReactionPayload) {
 		}
 	}
 	g.Mu.Unlock()
+}
+
+// Outcome returns the game's current outcome.
+func (g *Game) Outcome() chess.Outcome {
+	g.Mu.Lock()
+	defer g.Mu.Unlock()
+	return g.g.Outcome()
 }

--- a/internal/game/get_color_test.go
+++ b/internal/game/get_color_test.go
@@ -1,21 +1,33 @@
 package game
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestGetReturnsAssignedColor(t *testing.T) {
-	h := NewHub()
-	_, c1 := h.Get("g", "c1")
+	h := NewHub(nil)
+	_, c1, err := h.Get(context.Background(), "g", "c1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
 	if c1 == nil {
 		t.Fatalf("expected color for first client")
 	}
-	_, c2 := h.Get("g", "c2")
+	_, c2, err := h.Get(context.Background(), "g", "c2")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
 	if c2 == nil {
 		t.Fatalf("expected color for second client")
 	}
 	if *c1 == *c2 {
 		t.Fatalf("expected different colors, got %v and %v", *c1, *c2)
 	}
-	_, c3 := h.Get("g", "c3")
+	_, c3, err := h.Get(context.Background(), "g", "c3")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
 	if c3 != nil {
 		t.Fatalf("expected spectator for third client")
 	}

--- a/internal/game/hub.go
+++ b/internal/game/hub.go
@@ -1,16 +1,21 @@
 package game
 
 import (
+	"context"
+	"errors"
 	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/corentings/chess/v2"
+	"github.com/google/uuid"
+
+	"tinychess/internal/storage"
 )
 
-// NewHub creates a new game hub with cleanup goroutine
-func NewHub() *Hub {
-	h := &Hub{Games: make(map[string]*Game)}
-	// cleanup goroutine
+// NewHub creates a new game hub with an optional backing store.
+func NewHub(store *storage.Store) *Hub {
+	h := &Hub{Games: make(map[string]*Game), Store: store}
 	go func() {
 		for {
 			time.Sleep(5 * time.Minute)
@@ -29,67 +34,231 @@ func NewHub() *Hub {
 	return h
 }
 
-// Get retrieves an existing game or creates a new one. If a clientId is provided,
-// the first one becomes the owner and is assigned a random color. Subsequent
-// clients are assigned the opposite color. The returned color indicates the
-// assigned color for the given client, or nil if the client is a spectator or no
-// clientId was provided.
-func (h *Hub) Get(id, clientId string) (*Game, *chess.Color) {
+func newGameInstance(id string) *Game {
+	color := randomColor()
+	return &Game{
+		ID:         id,
+		g:          chess.NewGame(),
+		Watchers:   make(map[chan []byte]struct{}),
+		LastReact:  make(map[string]time.Time),
+		Clients:    make(map[string]chess.Color),
+		LastSeen:   time.Now(),
+		OwnerColor: color,
+	}
+}
+
+func randomColor() chess.Color {
+	if rand.Intn(2) == 0 {
+		return chess.Black
+	}
+	return chess.White
+}
+
+func colorFromString(s string) chess.Color {
+	switch s {
+	case "black":
+		return chess.Black
+	case "white":
+		return chess.White
+	default:
+		return chess.NoColor
+	}
+}
+
+func (g *Game) assignColor(clientID string) *chess.Color {
+	if clientID == "" {
+		return nil
+	}
+	g.Mu.Lock()
+	defer g.Mu.Unlock()
+
+	if col, ok := g.Clients[clientID]; ok {
+		if g.OwnerID == "" {
+			g.OwnerID = clientID
+			g.OwnerColor = col
+		}
+		c := col
+		return &c
+	}
+
+	if g.OwnerID == "" {
+		if g.OwnerColor == chess.NoColor {
+			g.OwnerColor = chess.White
+		}
+		g.OwnerID = clientID
+		g.Clients[clientID] = g.OwnerColor
+		c := g.OwnerColor
+		return &c
+	}
+
+	if len(g.Clients) < 2 {
+		var color chess.Color
+		if g.OwnerColor == chess.White {
+			color = chess.Black
+		} else {
+			color = chess.White
+		}
+		g.Clients[clientID] = color
+		c := color
+		return &c
+	}
+
+	return nil
+}
+
+func (h *Hub) hydrateGame(ctx context.Context, g *Game) error {
+	if h.Store == nil {
+		return nil
+	}
+	gameID, err := uuid.Parse(g.ID)
+	if err != nil {
+		return nil
+	}
+	persisted, err := h.Store.LoadGame(ctx, gameID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil
+		}
+		return err
+	}
+
+	if persisted.Game.FEN != "" {
+		if opt, err := chess.FEN(persisted.Game.FEN); err == nil {
+			g.g = chess.NewGame(opt)
+		}
+	}
+
+	g.LastSeen = persisted.Game.LastSeen
+	if g.LastSeen.IsZero() {
+		g.LastSeen = time.Now()
+	}
+
+	if persisted.Game.OwnerID != uuid.Nil {
+		g.OwnerID = persisted.Game.OwnerID.String()
+	}
+	if col := colorFromString(persisted.Game.OwnerColor); col != chess.NoColor {
+		g.OwnerColor = col
+	}
+
+	for _, player := range persisted.Players {
+		if !player.Active || player.UserID == uuid.Nil {
+			continue
+		}
+		col := colorFromString(player.Color)
+		if col == chess.NoColor {
+			continue
+		}
+		g.Clients[player.UserID.String()] = col
+	}
+
+	if g.OwnerID == "" && persisted.Game.OwnerID != uuid.Nil {
+		g.OwnerID = persisted.Game.OwnerID.String()
+	}
+
+	return nil
+}
+
+// Get retrieves an existing game or creates a new in-memory copy. If a client ID
+// is provided, the player will be assigned a color (if available). The assigned
+// color is returned when applicable.
+func (h *Hub) Get(ctx context.Context, id, clientID string) (*Game, *chess.Color, error) {
 	h.Mu.Lock()
 	g, ok := h.Games[id]
-	var assigned *chess.Color
 	if !ok {
-		color := chess.White
-		if rand.Intn(2) == 0 {
-			color = chess.Black
-		}
-		g = &Game{
-			g:          chess.NewGame(),
-			Watchers:   make(map[chan []byte]struct{}),
-			LastReact:  make(map[string]time.Time),
-			Clients:    make(map[string]chess.Color),
-			LastSeen:   time.Now(),
-			OwnerColor: color,
-		}
-		if clientId != "" {
-			g.OwnerID = clientId
-			g.Clients[clientId] = g.OwnerColor
-			c := g.OwnerColor
-			assigned = &c
+		g = newGameInstance(id)
+		if err := h.hydrateGame(ctx, g); err != nil {
+			h.Mu.Unlock()
+			return nil, nil, err
 		}
 		h.Games[id] = g
-		h.Mu.Unlock()
-		return g, assigned
 	}
 	h.Mu.Unlock()
 
-	if clientId != "" {
-		g.Mu.Lock()
-		if col, exists := g.Clients[clientId]; exists {
-			if g.OwnerID == "" {
-				g.OwnerID = clientId
-				g.OwnerColor = col
+	var assigned *chess.Color
+	if clientID != "" {
+		assigned = g.assignColor(clientID)
+		if assigned != nil && h.Store != nil {
+			gameUUID, err := uuid.Parse(id)
+			if err == nil {
+				userUUID, err := uuid.Parse(clientID)
+				if err == nil {
+					role := "player"
+					if g.OwnerID == clientID {
+						role = "owner"
+					}
+					now := time.Now()
+					if err := h.Store.EnsureUserSession(ctx, gameUUID, userUUID, assigned.String(), role, now); err != nil {
+						return g, assigned, err
+					}
+				}
 			}
-			c := col
-			assigned = &c
-		} else if g.OwnerID == "" {
-			g.OwnerID = clientId
-			g.Clients[clientId] = g.OwnerColor
-			c := g.OwnerColor
-			assigned = &c
-		} else if len(g.Clients) < 2 {
-			var color chess.Color
-			if g.OwnerColor == chess.White {
-				color = chess.Black
-			} else {
-				color = chess.White
-			}
-			g.Clients[clientId] = color
-			c := color
-			assigned = &c
 		}
-		g.Mu.Unlock()
 	}
 
-	return g, assigned
+	return g, assigned, nil
+}
+
+// CreateGame creates a brand-new game, stores it if a backing store exists, and
+// returns the identifier and assigned owner color.
+func (h *Hub) CreateGame(ctx context.Context, ownerID string) (string, chess.Color, error) {
+	ownerID = strings.TrimSpace(ownerID)
+	if ownerID == "" {
+		return "", chess.NoColor, errors.New("missing owner id")
+	}
+	ownerUUID, err := uuid.Parse(ownerID)
+	if err != nil {
+		return "", chess.NoColor, err
+	}
+
+	id := uuid.NewString()
+	g := newGameInstance(id)
+	g.OwnerID = ownerID
+	g.Clients[ownerID] = g.OwnerColor
+
+	h.Mu.Lock()
+	h.Games[id] = g
+	h.Mu.Unlock()
+
+	if h.Store != nil {
+		gameUUID, err := uuid.Parse(id)
+		if err != nil {
+			h.Mu.Lock()
+			delete(h.Games, id)
+			h.Mu.Unlock()
+			return "", chess.NoColor, err
+		}
+		if err := h.Store.CreateGame(ctx, gameUUID, ownerUUID, g.OwnerColor.String(), g.LastSeen); err != nil {
+			h.Mu.Lock()
+			delete(h.Games, id)
+			h.Mu.Unlock()
+			return "", chess.NoColor, err
+		}
+		if err := h.Store.EnsureUserSession(ctx, gameUUID, ownerUUID, g.OwnerColor.String(), "owner", g.LastSeen); err != nil {
+			h.Mu.Lock()
+			delete(h.Games, id)
+			h.Mu.Unlock()
+			return "", chess.NoColor, err
+		}
+		g.Mu.Lock()
+		state := g.StateLocked()
+		g.Mu.Unlock()
+		active := true
+		fen := state.FEN
+		pgn := state.PGN
+		status := state.Status
+		if err := h.Store.SaveGameState(ctx, gameUUID, storage.GameStateUpdate{
+			FEN:      &fen,
+			PGN:      &pgn,
+			Status:   &status,
+			Active:   &active,
+			LastSeen: &g.LastSeen,
+		}); err != nil {
+			h.Mu.Lock()
+			delete(h.Games, id)
+			h.Mu.Unlock()
+			return "", chess.NoColor, err
+		}
+	}
+
+	return id, g.OwnerColor, nil
 }

--- a/internal/game/types.go
+++ b/internal/game/types.go
@@ -5,16 +5,19 @@ import (
 	"time"
 
 	"github.com/corentings/chess/v2"
+	"tinychess/internal/storage"
 )
 
 // Hub manages all active chess games
 type Hub struct {
 	Mu    sync.Mutex
 	Games map[string]*Game
+	Store *storage.Store
 }
 
 // Game represents a single chess game with its state and watchers
 type Game struct {
+	ID         string
 	Mu         sync.Mutex
 	g          *chess.Game
 	Watchers   map[chan []byte]struct{}

--- a/internal/handlers/handle_move_test.go
+++ b/internal/handlers/handle_move_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"net/http/httptest"
 	"strings"
@@ -13,9 +14,12 @@ import (
 
 // Test that a move is rejected when the piece is not of the player's color.
 func TestHandleMoveWrongColor(t *testing.T) {
-	hub := game.NewHub()
-	h := NewHandler(hub)
-	g, _ := hub.Get("g1", "")
+	hub := game.NewHub(nil)
+	h := NewHandler(hub, nil)
+	g, _, err := hub.Get(context.Background(), "g1", "")
+	if err != nil {
+		t.Fatalf("get game: %v", err)
+	}
 	g.Clients["c1"] = chess.White
 
 	req := httptest.NewRequest("POST", "/move/g1", strings.NewReader(`{"uci":"a7a6","clientId":"c1"}`))
@@ -33,9 +37,12 @@ func TestHandleMoveWrongColor(t *testing.T) {
 
 // Test that a move is rejected when it is not the player's turn.
 func TestHandleMoveNotYourTurn(t *testing.T) {
-	hub := game.NewHub()
-	h := NewHandler(hub)
-	g, _ := hub.Get("g2", "")
+	hub := game.NewHub(nil)
+	h := NewHandler(hub, nil)
+	g, _, err := hub.Get(context.Background(), "g2", "")
+	if err != nil {
+		t.Fatalf("get game: %v", err)
+	}
 	g.Clients["c2"] = chess.Black
 
 	req := httptest.NewRequest("POST", "/move/g2", strings.NewReader(`{"uci":"a7a6","clientId":"c2"}`))
@@ -53,9 +60,12 @@ func TestHandleMoveNotYourTurn(t *testing.T) {
 
 // Test that a valid move by the correct player succeeds.
 func TestHandleMoveSuccess(t *testing.T) {
-	hub := game.NewHub()
-	h := NewHandler(hub)
-	g, _ := hub.Get("g3", "")
+	hub := game.NewHub(nil)
+	h := NewHandler(hub, nil)
+	g, _, err := hub.Get(context.Background(), "g3", "")
+	if err != nil {
+		t.Fatalf("get game: %v", err)
+	}
 	g.Clients["c1"] = chess.White
 
 	req := httptest.NewRequest("POST", "/move/g3", strings.NewReader(`{"uci":"e2e4","clientId":"c1"}`))

--- a/internal/handlers/handle_release_test.go
+++ b/internal/handlers/handle_release_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"net/http/httptest"
 	"strings"
@@ -12,9 +13,12 @@ import (
 )
 
 func TestHandleRelease(t *testing.T) {
-	hub := game.NewHub()
-	h := NewHandler(hub)
-	g, _ := hub.Get("g1", "owner")
+	hub := game.NewHub(nil)
+	h := NewHandler(hub, nil)
+	g, _, err := hub.Get(context.Background(), "g1", "owner")
+	if err != nil {
+		t.Fatalf("get game: %v", err)
+	}
 	g.Clients["other"] = chess.Black
 
 	req := httptest.NewRequest("POST", "/release/g1", strings.NewReader(`{"clientId":"owner","targetId":"other"}`))
@@ -34,9 +38,12 @@ func TestHandleRelease(t *testing.T) {
 }
 
 func TestHandleReleaseNotOwner(t *testing.T) {
-	hub := game.NewHub()
-	h := NewHandler(hub)
-	g, _ := hub.Get("g2", "owner")
+	hub := game.NewHub(nil)
+	h := NewHandler(hub, nil)
+	g, _, err := hub.Get(context.Background(), "g2", "owner")
+	if err != nil {
+		t.Fatalf("get game: %v", err)
+	}
 	g.Clients["other"] = chess.Black
 
 	req := httptest.NewRequest("POST", "/release/g2", strings.NewReader(`{"clientId":"notowner","targetId":"other"}`))

--- a/internal/handlers/middleware_test.go
+++ b/internal/handlers/middleware_test.go
@@ -1,40 +1,44 @@
 package handlers
 
 import (
+	"context"
 	"testing"
 
 	"tinychess/internal/game"
 )
 
-func newGame() *game.Game {
-	hub := game.NewHub()
-	g, _ := hub.Get("test", "")
+func newGame(t *testing.T) *game.Game {
+	hub := game.NewHub(nil)
+	g, _, err := hub.Get(context.Background(), "test", "")
+	if err != nil {
+		t.Fatalf("failed to create game: %v", err)
+	}
 	return g
 }
 
 func TestAppendPromotionIfPawnRank8(t *testing.T) {
-	g := newGame()
+	g := newGame(t)
 	if got := appendPromotionIfPawn(g, "a7a8"); got != "a7a8q" {
 		t.Fatalf("expected a7a8q got %s", got)
 	}
 }
 
 func TestAppendPromotionIfPawnRank1(t *testing.T) {
-	g := newGame()
+	g := newGame(t)
 	if got := appendPromotionIfPawn(g, "a7a1"); got != "a7a1q" {
 		t.Fatalf("expected a7a1q got %s", got)
 	}
 }
 
 func TestNoPromotionForQueen(t *testing.T) {
-	g := newGame()
+	g := newGame(t)
 	if got := appendPromotionIfPawn(g, "d1d8"); got != "d1d8" {
 		t.Fatalf("queen move modified: %s", got)
 	}
 }
 
 func TestNoPromotionForRook(t *testing.T) {
-	g := newGame()
+	g := newGame(t)
 	if got := appendPromotionIfPawn(g, "a8a1"); got != "a8a1" {
 		t.Fatalf("rook move modified: %s", got)
 	}

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -8,13 +8,20 @@ import (
 
 // Game represents a chess game.
 type Game struct {
-	ID        uuid.UUID `gorm:"type:uuid;default:gen_random_uuid();primaryKey"`
-	FEN       string
-	PGN       string
-	CreatedAt time.Time
-	UpdatedAt time.Time
-	Sessions  []GameSession
-	Moves     []Move
+	ID          uuid.UUID `gorm:"type:uuid;default:gen_random_uuid();primaryKey"`
+	FEN         string
+	PGN         string
+	OwnerID     uuid.UUID `gorm:"type:uuid;index"`
+	OwnerColor  string
+	Status      string
+	Result      string
+	Active      bool `gorm:"index"`
+	CompletedAt *time.Time
+	LastSeen    time.Time
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	Sessions    []GameSession
+	Moves       []Move
 }
 
 // GameSession represents an instance of a game session.
@@ -32,8 +39,11 @@ type UserSession struct {
 	ID            uuid.UUID `gorm:"type:uuid;default:gen_random_uuid();primaryKey"`
 	GameID        uuid.UUID `gorm:"type:uuid;index"`
 	GameSessionID uuid.UUID `gorm:"type:uuid;index"`
+	UserID        uuid.UUID `gorm:"type:uuid;index;uniqueIndex:idx_game_user"`
 	Color         string
 	Role          string
+	Active        bool
+	LastSeen      time.Time
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
 }
@@ -42,7 +52,9 @@ type UserSession struct {
 type Move struct {
 	ID        uuid.UUID `gorm:"type:uuid;default:gen_random_uuid();primaryKey"`
 	GameID    uuid.UUID `gorm:"type:uuid;index"`
+	UserID    uuid.UUID `gorm:"type:uuid;index"`
 	Number    int
 	UCI       string
+	Color     string
 	CreatedAt time.Time
 }

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -1,0 +1,247 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// Store wraps a gorm DB instance and provides helper methods for persisting games.
+type Store struct {
+	db *gorm.DB
+}
+
+// NewStore creates a new store helper from a gorm DB.
+func NewStore(db *gorm.DB) *Store {
+	if db == nil {
+		return nil
+	}
+	return &Store{db: db}
+}
+
+// DB exposes the underlying gorm DB instance.
+func (s *Store) DB() *gorm.DB {
+	if s == nil {
+		return nil
+	}
+	return s.db
+}
+
+// ErrNotFound is returned when a record is not found.
+var ErrNotFound = gorm.ErrRecordNotFound
+
+// GameStateUpdate represents a partial update to a game row.
+type GameStateUpdate struct {
+	FEN         *string
+	PGN         *string
+	Status      *string
+	Result      *string
+	Active      *bool
+	LastSeen    *time.Time
+	CompletedAt *time.Time
+}
+
+// CreateGame inserts a new game with the provided identifiers.
+func (s *Store) CreateGame(ctx context.Context, id, ownerID uuid.UUID, ownerColor string, lastSeen time.Time) error {
+	if s == nil {
+		return nil
+	}
+	game := Game{
+		ID:         id,
+		OwnerID:    ownerID,
+		OwnerColor: ownerColor,
+		Active:     true,
+		LastSeen:   lastSeen,
+	}
+	return s.db.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(&game).Error
+}
+
+// SaveGameState applies partial updates to the game row.
+func (s *Store) SaveGameState(ctx context.Context, id uuid.UUID, upd GameStateUpdate) error {
+	if s == nil {
+		return nil
+	}
+	updates := make(map[string]any)
+	if upd.FEN != nil {
+		updates["fen"] = *upd.FEN
+	}
+	if upd.PGN != nil {
+		updates["pgn"] = *upd.PGN
+	}
+	if upd.Status != nil {
+		updates["status"] = *upd.Status
+	}
+	if upd.Result != nil {
+		updates["result"] = *upd.Result
+	}
+	if upd.Active != nil {
+		updates["active"] = *upd.Active
+	}
+	if upd.LastSeen != nil {
+		updates["last_seen"] = *upd.LastSeen
+	}
+	if upd.CompletedAt != nil {
+		updates["completed_at"] = *upd.CompletedAt
+	}
+	if len(updates) == 0 {
+		return nil
+	}
+	return s.db.WithContext(ctx).Model(&Game{}).Where("id = ?", id).Updates(updates).Error
+}
+
+// EnsureUserSession upserts a user session record for a game.
+func (s *Store) EnsureUserSession(ctx context.Context, gameID, userID uuid.UUID, color, role string, lastSeen time.Time) error {
+	if s == nil {
+		return nil
+	}
+	session := UserSession{
+		GameID:   gameID,
+		UserID:   userID,
+		Color:    color,
+		Role:     role,
+		Active:   true,
+		LastSeen: lastSeen,
+	}
+	return s.db.WithContext(ctx).
+		Where("game_id = ? AND user_id = ?", gameID, userID).
+		Assign(map[string]any{
+			"color":     color,
+			"role":      role,
+			"active":    true,
+			"last_seen": lastSeen,
+		}).
+		FirstOrCreate(&session).Error
+}
+
+// DeactivateUserSession marks the given user session as inactive.
+func (s *Store) DeactivateUserSession(ctx context.Context, gameID, userID uuid.UUID) error {
+	if s == nil {
+		return nil
+	}
+	return s.db.WithContext(ctx).
+		Model(&UserSession{}).
+		Where("game_id = ? AND user_id = ?", gameID, userID).
+		Updates(map[string]any{"active": false}).Error
+}
+
+// RecordMove inserts a move row for the given game.
+func (s *Store) RecordMove(ctx context.Context, gameID, userID uuid.UUID, number int, uci, color string) error {
+	if s == nil {
+		return nil
+	}
+	move := Move{
+		GameID: gameID,
+		UserID: userID,
+		Number: number,
+		UCI:    uci,
+		Color:  color,
+	}
+	return s.db.WithContext(ctx).Create(&move).Error
+}
+
+// LoadGame fetches a persisted game and its active sessions.
+type PersistedGame struct {
+	Game    Game
+	Players []UserSession
+}
+
+func (s *Store) LoadGame(ctx context.Context, id uuid.UUID) (*PersistedGame, error) {
+	if s == nil {
+		return nil, gorm.ErrRecordNotFound
+	}
+	var game Game
+	if err := s.db.WithContext(ctx).First(&game, "id = ?", id).Error; err != nil {
+		return nil, err
+	}
+	var players []UserSession
+	if err := s.db.WithContext(ctx).
+		Where("game_id = ? AND active = ?", id, true).
+		Find(&players).Error; err != nil {
+		return nil, err
+	}
+	return &PersistedGame{Game: game, Players: players}, nil
+}
+
+// Stats represents aggregate counts for games.
+type Stats struct {
+	Started   int64 `json:"started"`
+	Completed int64 `json:"completed"`
+	Active    int64 `json:"active"`
+}
+
+// FetchStats aggregates counts for display on the home page.
+func (s *Store) FetchStats(ctx context.Context) (Stats, error) {
+	var stats Stats
+	if s == nil {
+		return stats, nil
+	}
+	if err := s.db.WithContext(ctx).Model(&Game{}).Count(&stats.Started).Error; err != nil {
+		return stats, err
+	}
+	if err := s.db.WithContext(ctx).Model(&Game{}).Where("active = ?", true).Count(&stats.Active).Error; err != nil {
+		return stats, err
+	}
+	if err := s.db.WithContext(ctx).Model(&Game{}).Where("completed_at IS NOT NULL").Count(&stats.Completed).Error; err != nil {
+		return stats, err
+	}
+	return stats, nil
+}
+
+// CompleteGame marks a game as finished with the provided status and result.
+func (s *Store) CompleteGame(ctx context.Context, id uuid.UUID, status, result string, completedAt time.Time) error {
+	if s == nil {
+		return nil
+	}
+	active := false
+	return s.SaveGameState(ctx, id, GameStateUpdate{
+		Status:      &status,
+		Result:      &result,
+		Active:      &active,
+		CompletedAt: &completedAt,
+	})
+}
+
+// SetActive updates the active flag for a game without changing other fields.
+func (s *Store) SetActive(ctx context.Context, id uuid.UUID, active bool) error {
+	if s == nil {
+		return nil
+	}
+	return s.SaveGameState(ctx, id, GameStateUpdate{Active: &active})
+}
+
+// UpdateLastSeen updates the last seen timestamp for a game.
+func (s *Store) UpdateLastSeen(ctx context.Context, id uuid.UUID, lastSeen time.Time) error {
+	if s == nil {
+		return nil
+	}
+	return s.SaveGameState(ctx, id, GameStateUpdate{LastSeen: &lastSeen})
+}
+
+// ForgetGame marks a game as ended by the owner forgetting it.
+func (s *Store) ForgetGame(ctx context.Context, id uuid.UUID, when time.Time) error {
+	if s == nil {
+		return nil
+	}
+	status := "Abandoned"
+	active := false
+	return s.SaveGameState(ctx, id, GameStateUpdate{
+		Status:      &status,
+		Active:      &active,
+		CompletedAt: &when,
+	})
+}
+
+// DeactivateAllSessions marks all sessions for the game as inactive.
+func (s *Store) DeactivateAllSessions(ctx context.Context, gameID uuid.UUID) error {
+	if s == nil {
+		return nil
+	}
+	return s.db.WithContext(ctx).Model(&UserSession{}).Where("game_id = ?", gameID).Updates(map[string]any{"active": false}).Error
+}
+
+// ErrMissingGame is returned when attempting to operate on a non-existing game.
+var ErrMissingGame = errors.New("game not found")

--- a/internal/templates/game.html
+++ b/internal/templates/game.html
@@ -511,8 +511,41 @@
           "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 
         // ---- IDs / elements ----
+        const USER_ID_KEY = "tinychess:userId";
         const CLIENT_ID_KEY = "tinychess:clientId";
-        let clientId = sessionStorage.getItem(CLIENT_ID_KEY) || "";
+        function generateId() {
+          if (window.crypto && typeof window.crypto.randomUUID === "function") {
+            return window.crypto.randomUUID();
+          }
+          const tpl = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx";
+          return tpl.replace(/[xy]/g, function (c) {
+            const r = (Math.random() * 16) | 0;
+            const v = c === "x" ? r : (r & 0x3) | 0x8;
+            return v.toString(16);
+          });
+        }
+        function ensureClientId() {
+          let id = "";
+          try {
+            id = localStorage.getItem(USER_ID_KEY) || "";
+          } catch {}
+          if (!id) {
+            try {
+              id = sessionStorage.getItem(CLIENT_ID_KEY) || "";
+            } catch {}
+          }
+          if (!id) {
+            id = generateId();
+          }
+          try {
+            localStorage.setItem(USER_ID_KEY, id);
+          } catch {}
+          try {
+            sessionStorage.setItem(CLIENT_ID_KEY, id);
+          } catch {}
+          return id;
+        }
+        let clientId = ensureClientId();
         // If the server didn't substitute {{GAME_ID}}, fall back to the path.
         const idFromServerRaw = "{{GAME_ID}}";
         const gameId =
@@ -1125,10 +1158,13 @@
               return;
             }
             if (st.kind === "state") {
-              if (!clientId && st.clientId) {
+              if (st.clientId) {
                 clientId = st.clientId;
                 try {
                   sessionStorage.setItem(CLIENT_ID_KEY, clientId);
+                } catch {}
+                try {
+                  localStorage.setItem(USER_ID_KEY, clientId);
                 } catch {}
               }
               if (st.role === "spectator") {

--- a/internal/templates/home.html
+++ b/internal/templates/home.html
@@ -138,6 +138,36 @@
         opacity: 0.85;
       }
 
+      .stats {
+        margin-top: 24px;
+        display: flex;
+        justify-content: center;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+
+      .stat-pill {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 10px 14px;
+        background: var(--panel);
+        border: 1px solid var(--btn-border);
+        border-radius: 10px;
+        min-width: 120px;
+      }
+
+      .stat-pill strong {
+        font-size: 18px;
+      }
+
+      .stat-pill span {
+        opacity: 0.8;
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+
       footer {
         opacity: 0.7;
         padding: 8px 14px 24px;
@@ -245,6 +275,7 @@
       <p style="margin-top: 25px">
         <a class="btn" href="/new" id="newgame2">New game</a>
       </p>
+      <div class="stats" id="stats"></div>
     </main>
 
     <section class="recent">
@@ -302,6 +333,68 @@
           }
         });
 
+        // ----- User identity -----
+        const USER_ID_KEY = "tinychess:userId";
+        function generateId() {
+          if (window.crypto && typeof window.crypto.randomUUID === "function") {
+            return window.crypto.randomUUID();
+          }
+          const tpl = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx";
+          return tpl.replace(/[xy]/g, function (c) {
+            const r = (Math.random() * 16) | 0;
+            const v = c === "x" ? r : (r & 0x3) | 0x8;
+            return v.toString(16);
+          });
+        }
+        function ensureUserId() {
+          let id = "";
+          try {
+            id = localStorage.getItem(USER_ID_KEY) || "";
+          } catch {}
+          if (!id) {
+            id = generateId();
+            try {
+              localStorage.setItem(USER_ID_KEY, id);
+            } catch {}
+          }
+          return id;
+        }
+        const userId = ensureUserId();
+
+        // ----- Stats -----
+        function renderStats(stats) {
+          const box = document.getElementById("stats");
+          if (!box) return;
+          const list = [
+            { label: "Being played", value: Number(stats.active || 0) },
+            { label: "Started", value: Number(stats.started || 0) },
+            { label: "Completed", value: Number(stats.completed || 0) },
+          ];
+          box.innerHTML = list
+            .map(function (item) {
+              return (
+                '<div class="stat-pill"><strong>' +
+                item.value.toLocaleString() +
+                "</strong><span>" +
+                item.label +
+                "</span></div>"
+              );
+            })
+            .join("");
+        }
+
+        async function loadStats() {
+          try {
+            const res = await fetch("/api/stats");
+            const data = await res.json().catch(() => null);
+            if (!data || !data.ok || !data.stats) return;
+            renderStats(data.stats);
+          } catch (e) {}
+        }
+
+        renderStats({ started: 0, completed: 0, active: 0 });
+        loadStats();
+
         // ----- Recent/active games -----
         const KEY = "tinychess:games:v1";
         function loadGames() {
@@ -327,6 +420,41 @@
           return Object.values(m).filter(function (g) {
             return !hasResult(g);
           });
+        }
+
+        let creatingGame = false;
+        async function createGame() {
+          if (creatingGame) return;
+          creatingGame = true;
+          try {
+            const res = await fetch("/new", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ userId: userId }),
+            });
+            const data = await res.json().catch(() => null);
+            if (data && data.ok && data.id) {
+              location.href = "/" + data.id;
+              return;
+            }
+            alert("Unable to create a game right now. Please try again.");
+          } catch (e) {
+            alert("Unable to create a game right now. Please try again.");
+          } finally {
+            creatingGame = false;
+          }
+        }
+
+        async function forgetRemote(id) {
+          if (!id) return;
+          try {
+            await fetch("/forget/" + id, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ userId: userId }),
+            });
+          } catch (e) {}
+          loadStats();
         }
 
         function renderRecent() {
@@ -405,6 +533,7 @@
             const m = loadGames();
             delete m[id];
             saveGames(m);
+            forgetRemote(id);
             renderRecent();
           }
         });
@@ -415,7 +544,10 @@
             act.sort(byLastSeenDesc);
             location.href = "/" + act[0].id;
             ev.preventDefault();
+            return;
           }
+          ev.preventDefault();
+          createGame();
         }
         ["newgame", "newgame2"].forEach(function (id) {
           const el = document.getElementById(id);

--- a/main.go
+++ b/main.go
@@ -20,17 +20,20 @@ func main() {
 
 	templates.SetVersion(commit)
 
+	var store *storage.Store
 	if dsn := os.Getenv("DATABASE_URL"); dsn != "" {
-		if _, err := storage.New(dsn); err != nil {
+		db, err := storage.New(dsn)
+		if err != nil {
 			log.Fatalf("failed to initialize database: %v", err)
 		}
+		store = storage.NewStore(db)
 	}
 
 	// Initialize game hub
-	hub := game.NewHub()
+	hub := game.NewHub(store)
 
 	// Initialize HTTP handlers
-	h := handlers.NewHandler(hub)
+	h := handlers.NewHandler(hub, store)
 
 	// Register routes
 	http.HandleFunc("/new", h.HandleNew)
@@ -38,6 +41,8 @@ func main() {
 	http.HandleFunc("/move/", h.HandleMove)
 	http.HandleFunc("/react/", h.HandleReact)
 	http.HandleFunc("/release/", h.HandleRelease)
+	http.HandleFunc("/forget/", h.HandleForget)
+	http.HandleFunc("/api/stats", h.HandleStats)
 	http.HandleFunc("/", h.HandlePage)
 
 	log.Printf("Tiny Chess listening on http://localhost:8080 …")


### PR DESCRIPTION
## Summary
- add a storage helper and update models so games, sessions, and moves persist in Postgres
- wire the hub and handlers into the new storage layer, including stats and forget endpoints
- update the UI to use a persistent user id, POST when creating/forgetting games, and render live stats

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68c8d0927da88320ad115e53a8bdc088