### PR TITLE
Fix database unique constraint for user sessions

### DIFF
--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -14,7 +14,13 @@ func New(dsn string) (*gorm.DB, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := db.Exec("DROP INDEX IF EXISTS idx_game_user").Error; err != nil {
+		return nil, err
+	}
 	if err := db.AutoMigrate(&Game{}, &GameSession{}, &UserSession{}, &Move{}); err != nil {
+		return nil, err
+	}
+	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_user_sessions_game_user ON user_sessions (game_id, user_id)").Error; err != nil {
 		return nil, err
 	}
 	return db, nil

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -37,9 +37,9 @@ type GameSession struct {
 // UserSession links a user to a game session.
 type UserSession struct {
 	ID            uuid.UUID `gorm:"type:uuid;default:gen_random_uuid();primaryKey"`
-	GameID        uuid.UUID `gorm:"type:uuid;index"`
+	GameID        uuid.UUID `gorm:"type:uuid;index;uniqueIndex:idx_user_sessions_game_user"`
 	GameSessionID uuid.UUID `gorm:"type:uuid;index"`
-	UserID        uuid.UUID `gorm:"type:uuid;index;uniqueIndex:idx_game_user"`
+	UserID        uuid.UUID `gorm:"type:uuid;index;uniqueIndex:idx_user_sessions_game_user"`
 	Color         string
 	Role          string
 	Active        bool


### PR DESCRIPTION
## Summary
- allow multiple sessions per user by scoping the unique index to each game
- clean up the old unique index and ensure the composite index exists during DB init

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68c8e60841c483208896650d9788fe87