### PR TITLE
Add vanilla Hashbrown coach integration

### DIFF
--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -1,8 +1,10 @@
 package handlers
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -18,12 +20,18 @@ import (
 
 // Handler contains dependencies for HTTP handlers
 type Handler struct {
-	Hub *game.Hub
+	Hub             *game.Hub
+	HashbrownURL    string
+	HashbrownAPIKey string
 }
 
 // NewHandler creates a new handler instance
-func NewHandler(hub *game.Hub) *Handler {
-	return &Handler{Hub: hub}
+func NewHandler(hub *game.Hub, hashbrownURL, hashbrownAPIKey string) *Handler {
+	return &Handler{
+		Hub:             hub,
+		HashbrownURL:    hashbrownURL,
+		HashbrownAPIKey: hashbrownAPIKey,
+	}
 }
 
 // HandleNew creates a new game and redirects to it
@@ -240,6 +248,83 @@ func (h *Handler) HandleRelease(w http.ResponseWriter, r *http.Request) {
 	WriteJSON(w, http.StatusOK, map[string]any{"ok": true})
 }
 
+// HandleCoach proxies structured coach requests to Hashbrown.
+func (h *Handler) HandleCoach(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		WriteJSON(w, http.StatusMethodNotAllowed, map[string]any{"ok": false, "error": "method not allowed"})
+		return
+	}
+
+	if h.HashbrownURL == "" {
+		WriteJSON(w, http.StatusServiceUnavailable, map[string]any{"ok": false, "error": "coach unavailable"})
+		return
+	}
+
+	var req CoachRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		WriteJSON(w, http.StatusBadRequest, map[string]any{"ok": false, "error": "bad json"})
+		return
+	}
+
+	if strings.TrimSpace(req.FEN) == "" {
+		WriteJSON(w, http.StatusBadRequest, map[string]any{"ok": false, "error": "missing fen"})
+		return
+	}
+
+	payload, err := json.Marshal(req)
+	if err != nil {
+		WriteJSON(w, http.StatusInternalServerError, map[string]any{"ok": false, "error": "failed to encode request"})
+		return
+	}
+
+	hbReq, err := http.NewRequestWithContext(r.Context(), http.MethodPost, h.HashbrownURL, bytes.NewReader(payload))
+	if err != nil {
+		WriteJSON(w, http.StatusInternalServerError, map[string]any{"ok": false, "error": "failed to build request"})
+		return
+	}
+	hbReq.Header.Set("Content-Type", "application/json")
+	if h.HashbrownAPIKey != "" {
+		hbReq.Header.Set("Authorization", "Bearer "+h.HashbrownAPIKey)
+	}
+
+	client := &http.Client{Timeout: 12 * time.Second}
+	resp, err := client.Do(hbReq)
+	if err != nil {
+		logging.Debugf("hashbrown request failed: %v", err)
+		WriteJSON(w, http.StatusBadGateway, map[string]any{"ok": false, "error": "coach request failed"})
+		return
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		WriteJSON(w, http.StatusBadGateway, map[string]any{"ok": false, "error": "failed to read coach response"})
+		return
+	}
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		logging.Debugf("hashbrown error: status=%d body=%s", resp.StatusCode, string(body))
+		WriteJSON(w, http.StatusBadGateway, map[string]any{"ok": false, "error": "coach error"})
+		return
+	}
+
+	var hbRaw map[string]any
+	if err := json.Unmarshal(body, &hbRaw); err != nil {
+		WriteJSON(w, http.StatusBadGateway, map[string]any{"ok": false, "error": "invalid coach response"})
+		return
+	}
+
+	suggestions := buildCoachSuggestions(req.FEN, hbRaw)
+	explanation := extractCoachExplanation(hbRaw)
+
+	WriteJSON(w, http.StatusOK, CoachResponse{
+		OK:          true,
+		Suggestions: suggestions,
+		Explanation: explanation,
+		Raw:         hbRaw,
+	})
+}
+
 // ClientIP extracts the client IP from the request
 func ClientIP(r *http.Request) string {
 	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
@@ -250,4 +335,101 @@ func ClientIP(r *http.Request) string {
 		return host
 	}
 	return r.RemoteAddr
+}
+
+// CoachRequest is the structured payload sent to Hashbrown.
+type CoachRequest struct {
+	FEN         string   `json:"fen"`
+	PGN         string   `json:"pgn"`
+	MoveHistory []string `json:"moveHistory"`
+	SideToMove  string   `json:"sideToMove"`
+	Question    string   `json:"question"`
+}
+
+// CoachSuggestion is a validated coach move.
+type CoachSuggestion struct {
+	Move  string `json:"move"`
+	Valid bool   `json:"valid"`
+}
+
+// CoachResponse is returned to the client.
+type CoachResponse struct {
+	OK          bool              `json:"ok"`
+	Error       string            `json:"error,omitempty"`
+	Suggestions []CoachSuggestion `json:"suggestions,omitempty"`
+	Explanation string            `json:"explanation,omitempty"`
+	Raw         map[string]any    `json:"raw,omitempty"`
+}
+
+func buildCoachSuggestions(fen string, hbRaw map[string]any) []CoachSuggestion {
+	candidates := extractMoveCandidates(hbRaw)
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	fenOpt, err := chess.FEN(fen)
+	if err != nil {
+		return nil
+	}
+	tmp := chess.NewGame(fenOpt)
+	uci := chess.UCINotation{}
+	san := chess.AlgebraicNotation{}
+
+	out := make([]CoachSuggestion, 0, len(candidates))
+	for _, move := range candidates {
+		mv, err := uci.Decode(tmp.Position(), move)
+		if err != nil {
+			mv, err = san.Decode(tmp.Position(), move)
+		}
+		out = append(out, CoachSuggestion{
+			Move:  move,
+			Valid: err == nil && mv != nil,
+		})
+	}
+	return out
+}
+
+func extractMoveCandidates(hbRaw map[string]any) []string {
+	keys := []string{"moves", "suggestions", "candidateMoves", "candidates"}
+	for _, key := range keys {
+		if val, ok := hbRaw[key]; ok {
+			return normalizeMoveList(val)
+		}
+	}
+	return nil
+}
+
+func normalizeMoveList(val any) []string {
+	switch v := val.(type) {
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok && strings.TrimSpace(s) != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	case []string:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if strings.TrimSpace(item) != "" {
+				out = append(out, item)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func extractCoachExplanation(hbRaw map[string]any) string {
+	keys := []string{"explanation", "analysis", "reasoning", "summary"}
+	for _, key := range keys {
+		if val, ok := hbRaw[key]; ok {
+			if s, ok := val.(string); ok {
+				return s
+			}
+		}
+	}
+	return ""
 }

--- a/internal/templates/game.html
+++ b/internal/templates/game.html
@@ -263,6 +263,81 @@
         min-height: 0;
       }
 
+      .coach {
+        margin-top: 12px;
+        padding-top: 12px;
+        border-top: 1px solid var(--btn-border);
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .coach label {
+        font-weight: 600;
+      }
+
+      .coach-input {
+        flex: 1;
+        min-width: 180px;
+        padding: 8px 10px;
+        border-radius: 10px;
+        border: 1px solid var(--btn-border);
+        background: var(--btn-bg);
+        color: var(--btn-text);
+      }
+
+      .coach-input:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+        border-color: transparent;
+      }
+
+      .coach-output {
+        background: var(--tertiary);
+        border-radius: 12px;
+        padding: 10px;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+
+      .coach-output pre {
+        margin: 0;
+        white-space: pre-wrap;
+      }
+
+      .coach-suggestions {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        font-weight: 600;
+      }
+
+      .coach-suggestion {
+        display: flex;
+        gap: 6px;
+        align-items: center;
+      }
+
+      .coach-tag {
+        font-size: 11px;
+        padding: 2px 6px;
+        border-radius: 999px;
+        border: 1px solid transparent;
+      }
+
+      .coach-tag.valid {
+        background: rgba(34, 197, 94, 0.15);
+        color: var(--ok);
+        border-color: rgba(34, 197, 94, 0.4);
+      }
+
+      .coach-tag.invalid {
+        background: rgba(239, 68, 68, 0.15);
+        color: var(--err);
+        border-color: rgba(239, 68, 68, 0.4);
+      }
+
       .mono {
         font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
           "Liberation Mono", monospace;
@@ -479,6 +554,22 @@
 
         <div class="row"><strong>Turn:</strong> <span id="turn"></span></div>
         <div class="status" id="status"></div>
+        <div class="coach">
+          <label for="coach-question">Ask the coach</label>
+          <div class="row">
+            <input
+              id="coach-question"
+              class="coach-input"
+              type="text"
+              placeholder="What’s my best move?"
+            />
+            <button class="btn" id="coach-ask">Ask Coach</button>
+          </div>
+          <div class="coach-output">
+            <div class="coach-suggestions" id="coach-suggestions"></div>
+            <pre id="coach-response" class="mono"></pre>
+          </div>
+        </div>
 
         <div class="rx" id="rx"></div>
         <div class="actions">
@@ -527,6 +618,11 @@
         const lanEl = document.getElementById("lan");
         const capWhiteEl = document.getElementById("cap_by_white");
         const capBlackEl = document.getElementById("cap_by_black");
+        const coachQuestionEl = document.getElementById("coach-question");
+        const coachAskEl = document.getElementById("coach-ask");
+        const coachSuggestionsEl =
+          document.getElementById("coach-suggestions");
+        const coachResponseEl = document.getElementById("coach-response");
         const rxEl = document.getElementById("rx");
         const reactBtn = document.getElementById("reactbtn");
         const emojiDialog = document.getElementById("emojiDialog");
@@ -540,6 +636,7 @@
         let isSpectator = false;
         let gameOver = false;
         let prevCaptured = { byWhite: [], byBlack: [] };
+        let currentState = { fen: START_FEN, pgn: "", turn: "w" };
 
         function loadRecent() {
           try {
@@ -978,6 +1075,105 @@
           return lines.join("\n");
         }
 
+        function parseMoveHistory(pgn) {
+          if (!pgn) return [];
+          const tokens = pgn.trim().split(/\s+/);
+          const moves = [];
+          for (const t of tokens) {
+            if (/^\d+\.$/.test(t)) continue;
+            if (/^(1-0|0-1|1\/2-1\/2|\*)$/.test(t)) continue;
+            moves.push(t);
+          }
+          return moves;
+        }
+
+        function buildCoachPayload() {
+          const fen = currentState.fen || START_FEN;
+          const sideToken = (fen.split(" ")[1] || "w").toLowerCase();
+          const sideToMove = sideToken === "b" ? "black" : "white";
+          const pgn = currentState.pgn || "";
+          return {
+            fen: fen,
+            pgn: pgn,
+            moveHistory: parseMoveHistory(pgn),
+            sideToMove: sideToMove,
+            question: (coachQuestionEl.value || "").trim(),
+          };
+        }
+
+        function renderCoachResult(data) {
+          if (coachSuggestionsEl) coachSuggestionsEl.innerHTML = "";
+          if (coachResponseEl) coachResponseEl.textContent = "";
+          if (!data || !data.ok) {
+            if (coachResponseEl)
+              coachResponseEl.textContent =
+                (data && data.error) || "Coach unavailable.";
+            return;
+          }
+
+          if (coachSuggestionsEl && data.suggestions && data.suggestions.length) {
+            for (const s of data.suggestions) {
+              const row = document.createElement("div");
+              row.className = "coach-suggestion";
+              const move = document.createElement("span");
+              move.textContent = s.move;
+              const tag = document.createElement("span");
+              tag.className = "coach-tag " + (s.valid ? "valid" : "invalid");
+              tag.textContent = s.valid ? "legal" : "illegal";
+              row.appendChild(move);
+              row.appendChild(tag);
+              coachSuggestionsEl.appendChild(row);
+            }
+          }
+
+          if (coachResponseEl) {
+            if (data.explanation) {
+              coachResponseEl.textContent = data.explanation;
+            } else if (data.raw) {
+              coachResponseEl.textContent = JSON.stringify(data.raw, null, 2);
+            } else {
+              coachResponseEl.textContent = "Coach response received.";
+            }
+          }
+        }
+
+        async function askCoach() {
+          if (!gameId) {
+            renderCoachResult({ ok: false, error: "No game id." });
+            return;
+          }
+          const payload = buildCoachPayload();
+          if (!payload.question) {
+            renderCoachResult({ ok: false, error: "Ask a question first." });
+            return;
+          }
+          if (coachResponseEl) coachResponseEl.textContent = "Thinking…";
+          if (coachSuggestionsEl) coachSuggestionsEl.innerHTML = "";
+          try {
+            const resp = await fetch("/coach/" + gameId, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(payload),
+            });
+            const data = await resp.json().catch(() => null);
+            renderCoachResult(data);
+          } catch (e) {
+            renderCoachResult({ ok: false, error: "Coach request failed." });
+          }
+        }
+
+        if (coachAskEl) {
+          coachAskEl.addEventListener("click", askCoach);
+        }
+        if (coachQuestionEl) {
+          coachQuestionEl.addEventListener("keydown", (e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              askCoach();
+            }
+          });
+        }
+
         function formatUCIMoves(uciList) {
           if (!uciList || !uciList.length) return "";
           let out = [];
@@ -1142,6 +1338,11 @@
                 releaseBtn.style.display = isSpectator ? "none" : "";
               lastMoveSquares = deriveLastMoveSquares(st.uci || []);
               renderFEN(st.fen);
+              currentState = {
+                fen: st.fen || START_FEN,
+                pgn: st.pgn || "",
+                turn: st.turn || "w",
+              };
               updateTurn(st);
               pgnEl.textContent = formatPGNLines(st.pgn || "");
               movesEl.style.display = (st.pgn || "").trim()

--- a/main.go
+++ b/main.go
@@ -30,7 +30,9 @@ func main() {
 	hub := game.NewHub()
 
 	// Initialize HTTP handlers
-	h := handlers.NewHandler(hub)
+	hashbrownURL := os.Getenv("HASHBROWN_API_URL")
+	hashbrownAPIKey := os.Getenv("HASHBROWN_API_KEY")
+	h := handlers.NewHandler(hub, hashbrownURL, hashbrownAPIKey)
 
 	// Register routes
 	http.HandleFunc("/new", h.HandleNew)
@@ -38,6 +40,7 @@ func main() {
 	http.HandleFunc("/move/", h.HandleMove)
 	http.HandleFunc("/react/", h.HandleReact)
 	http.HandleFunc("/release/", h.HandleRelease)
+	http.HandleFunc("/coach/", h.HandleCoach)
 	http.HandleFunc("/", h.HandlePage)
 
 	log.Printf("Tiny Chess listening on http://localhost:8080 …")


### PR DESCRIPTION
### Motivation
- Integrate a lightweight coach assistant using Hashbrown to provide move suggestions and human-readable explanations from structured board state.
- Keep API credentials off the client by proxying coach requests through the server and make the coach configurable via environment variables.
- Validate candidate moves server-side to ensure suggestions are legal for the current position.

### Description
- Add `HashbrownURL` and `HashbrownAPIKey` fields to the HTTP `Handler` and change `NewHandler` to accept those values from the environment.
- Implement `HandleCoach` which accepts a structured `CoachRequest`, forwards it to the configured Hashbrown endpoint, parses the response, and returns a simplified `CoachResponse` including validated `CoachSuggestion` entries.
- Add client-side UI and wiring in `internal/templates/game.html` (markup, CSS, and vanilla JS) to collect FEN/PGN/question payloads, POST to `/coach/<gameId>`, and render suggestions and explanations.
- Wire the new `/coach/` route in `main.go` and add helper functions to extract moves and explanation text from varied Hashbrown response shapes.

### Testing
- Ran `gofmt -w` to format modified Go files and it completed successfully.
- Launched the server with `go run .` and observed the server start message, indicating successful startup.
- Checked the site root with `curl -I http://127.0.0.1:8080/` and received an `HTTP/1.1 200 OK` response, confirming the server serves pages.
- Attempted an automated Playwright screenshot to exercise the UI, but the browser container could not connect (Playwright `net::ERR_CONNECTION_REFUSED`), so the end-to-end browser test failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946a0bac1208320bba96ade4c8a2d59)